### PR TITLE
Remove stop and dispose from FrameEncoders

### DIFF
--- a/modules/core/src/encoders/encoder.js
+++ b/modules/core/src/encoders/encoder.js
@@ -23,10 +23,6 @@ export default class Encoder {
   start() {
     throw new Error('Encoder: Implement a start function');
   }
-  /** @type {() => void} */
-  stop() {
-    throw new Error('Encoder: Implement a stop function');
-  }
   /** @type {(canvas: HTMLCanvasElement) => Promise<void>} */
   async add(canvas) {
     throw new Error('Encoder: Implement an add function');
@@ -34,9 +30,5 @@ export default class Encoder {
   /** @type {() => Promise<any>} */
   async save() {
     throw new Error('Encoder: Implement a save function');
-  }
-  /** @type {() => void} */
-  dispose() {
-    throw new Error('Encoder: Implement a dispose function');
   }
 }

--- a/modules/core/src/encoders/tar/tar-encoder.js
+++ b/modules/core/src/encoders/tar/tar-encoder.js
@@ -39,11 +39,11 @@ class TarEncoder extends FrameEncoder {
     this.start = this.start.bind(this);
     this.add = this.add.bind(this);
     this.save = this.save.bind(this);
-    this.dispose = this.dispose.bind(this);
   }
 
   start() {
-    this.dispose();
+    this.tape = new Tar();
+    this.count = 0;
   }
 
   /** @param {HTMLCanvasElement} canvas */
@@ -73,11 +73,6 @@ class TarEncoder extends FrameEncoder {
 
   async save() {
     return Promise.resolve(this.tape.save());
-  }
-
-  dispose() {
-    this.tape = new Tar();
-    this.count = 0;
   }
 }
 

--- a/modules/core/src/encoders/utils/preview-encoder.js
+++ b/modules/core/src/encoders/utils/preview-encoder.js
@@ -21,8 +21,11 @@
 import FrameEncoder from '../frame-encoder';
 export default class PreviewEncoder extends FrameEncoder {
   af;
-  start() {}
-  stop() {}
+  start() {
+    if (this.af) {
+      cancelAnimationFrame(this.af);
+    }
+  }
   async add(canvas) {
     const animationFrame = new Promise(resolve => {
       if (this.af) {
@@ -33,11 +36,9 @@ export default class PreviewEncoder extends FrameEncoder {
     return animationFrame;
   }
   async save() {
-    await Promise.resolve();
-  }
-  dispose() {
     if (this.af) {
       cancelAnimationFrame(this.af);
     }
+    await Promise.resolve();
   }
 }

--- a/modules/core/src/encoders/video/stream-encoder.js
+++ b/modules/core/src/encoders/video/stream-encoder.js
@@ -45,11 +45,12 @@ class StreamEncoder extends FrameEncoder {
     this.start = this.start.bind(this);
     this.add = this.add.bind(this);
     this.save = this.save.bind(this);
-    this.dispose = this.dispose.bind(this);
   }
 
   start() {
-    this.dispose();
+    this.stream = null;
+    this.mediaRecorder = null;
+    this.chunks = [];
   }
 
   /**
@@ -83,12 +84,6 @@ class StreamEncoder extends FrameEncoder {
     });
 
     return waiting;
-  }
-
-  dispose() {
-    this.stream = null;
-    this.mediaRecorder = null;
-    this.chunks = [];
   }
 }
 

--- a/modules/core/src/encoders/video/webm-encoder.js
+++ b/modules/core/src/encoders/video/webm-encoder.js
@@ -41,21 +41,19 @@ class WebMEncoder extends FrameEncoder {
     this.extension = '.webm';
     this.mimeType = 'video/webm';
 
+    this.videoWriter = null;
+    this.start = this.start.bind(this);
+    this.add = this.add.bind(this);
+    this.save = this.save.bind(this);
+  }
+
+  start() {
     this.videoWriter = new WebMWriter({
       quality: this.quality,
       fileWriter: null,
       fd: null,
       frameRate: this.framerate
     });
-
-    this.start = this.start.bind(this);
-    this.add = this.add.bind(this);
-    this.save = this.save.bind(this);
-    this.dispose = this.dispose.bind(this);
-  }
-
-  start() {
-    this.dispose();
   }
 
   /** @param {HTMLCanvasElement} canvas */
@@ -69,15 +67,6 @@ class WebMEncoder extends FrameEncoder {
    */
   async save() {
     return this.videoWriter.complete();
-  }
-
-  dispose() {
-    this.videoWriter = new WebMWriter({
-      quality: this.quality,
-      fileWriter: null,
-      fd: null,
-      frameRate: this.framerate
-    });
   }
 }
 


### PR DESCRIPTION
These functions are not used anymore, so the interface can be simplified.