### PR TITLE
Renable PNGEncoder blank (transparent) frames

### DIFF
--- a/modules/core/src/encoders/tar/tar-encoder.js
+++ b/modules/core/src/encoders/tar/tar-encoder.js
@@ -55,7 +55,7 @@ class TarEncoder extends FrameEncoder {
     const waitingForLoad = new Promise((resolve, reject) => {
       // filtering out blank canvases
       if (checkIfBlank(b64)) {
-        reject('BLANK');
+        // reject('BLANK');
       }
 
       fileReader.onload = () => {

--- a/modules/core/src/encoders/utils/index.js
+++ b/modules/core/src/encoders/utils/index.js
@@ -42,7 +42,7 @@ export function getBase64(canvas, type, quality) {
  */
 export function checkIfBlank(b64) {
   if (b64.length < 100000) {
-    console.error('SMALL IMAGE!', b64, b64.length);
+    console.warn('Possibly blank image!', b64, b64.length);
     return true;
   }
   return false;


### PR DESCRIPTION
In rare situations when a canvas is captured before an animation frame is finished, toDataUrl can return a nearly empty string. It is useful to warn when this happens, but it is no longer considered an error since proper usage of the library guarantees the canvas is captured appropriately. 

The only time we expect this nearly empty string is when capturing a truly empty frame, such as a transparent PNG when deckgl doesn't have anything to render. 
 
A regression could reintroduce this issue, especially when @deck.gl/mapbox support is added (fusing canvases is a fragile operation).

See a before and after example on [gdrive](https://drive.google.com/drive/folders/1-e9yY4W33moZF_ewCTUPOeFsGcHh66Ex?usp=sharing)