### PR TITLE
Add util supportedMimeTypes

### DIFF
--- a/modules/core/src/encoders/utils/index.js
+++ b/modules/core/src/encoders/utils/index.js
@@ -62,3 +62,21 @@ export function getBlob(base64, type) {
   }
   return new Blob([arr], {type});
 }
+
+export function supportedMimeTypes() {
+  const types = [
+    'video/webm',
+    'audio/webm',
+    'video/webm;codecs=vp8',
+    'video/webm;codecs=daala',
+    'video/webm;codecs=h264',
+    'audio/webm;codecs=opus',
+    'video/mpeg',
+    'image/webp'
+  ];
+
+  return types.filter(type => {
+    // @ts-ignore
+    return MediaRecorder.isTypeSupported(type);
+  });
+}


### PR DESCRIPTION
I'd like to add an example where people can test the codecs supported by their browsers. We can show which encoders are supported too.