### PR TITLE
Refactor encoder settings and scene settings api

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,10 +59,10 @@ function getKeyframes(animationLoop, data) {
 }
 
 export function sceneBuilder(animationLoop) {
-  const length = 5000;
+  const lengthMs = 5000;
   const data = [{sourcePosition: [-122.41669, 37.7853], targetPosition: [-122.41669, 37.781]}];
   const keyframes = getKeyframes(animationLoop, data);
-  return new DeckScene({animationLoop, length, keyframes, data, renderLayers});
+  return new DeckScene({animationLoop, keyframes, data, renderLayers, lengthMs, width: 1920, height: 1080});
 }
 ```
 
@@ -80,25 +80,24 @@ import {sceneBuilder} from './scene';
 
 const adapter = new DeckAdapter(sceneBuilder, WebMEncoder);
 
+/** @type {import('@hubble.gl/core/src/types').FrameEncoderSettings} */
+const encoderSettings = {
+  framerate: 30
+}
+
 export default function App() {
   const deckgl = useRef(null);
   const [ready, setReady] = useState(false);
   const [busy, setBusy] = useState(false);
   const nextFrame = useNextFrame();
 
-  if (busy) {
-    adapter.update(nextFrame);
-  }
-
   return (
     <div style={{position: 'relative'}}>
       <DeckGL
-        width={1920}
-        height={1080}
         ref={deckgl}
         {...adapter.getProps(deckgl, setReady, nextFrame)}
       />
-      <div style={{position: 'absolute'}}>{ready && <BasicControls adapter={adapter} busy={busy} setBusy={setBusy} />}</div>
+      <div style={{position: 'absolute'}}>{ready && <BasicControls adapter={adapter} busy={busy} setBusy={setBusy} encoderSettings={encoderSettings}/>}</div>
     </div>
   );
 }

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,5 +1,18 @@
 # Whats New
 
-## 1.0.0
+## 1.0.1
 
 Initial release.
+
+## 1.1.0 (draft)
+
+- Allow user to change encoder during runtime #1
+  - Encoders are constructed right before rendering starts, instead of when a scene is defined.
+  - Refactored encoder settings to be namespaced by encoder (`jpeg` settings are under `jpeg`, etc..).
+  - DeckAdapter.render now accepts a onStop callback.
+- Remove stop and dispose from FrameEncoders #3
+- Allow PNGEncoder transparent frames #4
+- Refactor encoder settings and scene settings api #8
+  - scene settings are defined at scene load time, so you can set scene resolution and animation length there.
+  - encoder settings are defined before every render, so you can set seek options there.
+- Gif Encoder #7

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -6,13 +6,12 @@ Initial release.
 
 ## 1.1.0 (draft)
 
-- Allow user to change encoder during runtime [#1](https://github.com/uber/hubble.gl/pull/1)
-  - Encoders are constructed right before rendering starts, instead of when a scene is defined.
-  - Refactored encoder settings to be namespaced by encoder (`jpeg` settings are under `jpeg`, etc..).
-  - DeckAdapter.render now accepts a onStop callback.
+- Encoders are constructed right before rendering starts, instead of when a scene is defined. [#1](https://github.com/uber/hubble.gl/pull/1)
+- DeckAdapter.render now accepts a onStop callback.
 - Remove stop and dispose from FrameEncoders [#3](https://github.com/uber/hubble.gl/pull/3)
 - Allow PNGEncoder transparent frames [#4](https://github.com/uber/hubble.gl/pull/4)
 - Refactor encoder settings and scene settings api [#8](https://github.com/uber/hubble.gl/pull/8)
   - scene settings are defined at scene load time, so you can set scene resolution and animation length there.
   - encoder settings are defined before every render, so you can set seek options there.
+  - format-specific encoder settings are namespaced by encoder (`jpeg` settings are under `jpeg`, etc..).
 - Gif Encoder [#7](https://github.com/uber/hubble.gl/pull/7)

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -6,13 +6,13 @@ Initial release.
 
 ## 1.1.0 (draft)
 
-- Allow user to change encoder during runtime #1
+- Allow user to change encoder during runtime [#1](https://github.com/uber/hubble.gl/pull/1)
   - Encoders are constructed right before rendering starts, instead of when a scene is defined.
   - Refactored encoder settings to be namespaced by encoder (`jpeg` settings are under `jpeg`, etc..).
   - DeckAdapter.render now accepts a onStop callback.
-- Remove stop and dispose from FrameEncoders #3
-- Allow PNGEncoder transparent frames #4
-- Refactor encoder settings and scene settings api #8
+- Remove stop and dispose from FrameEncoders [#3](https://github.com/uber/hubble.gl/pull/3)
+- Allow PNGEncoder transparent frames [#4](https://github.com/uber/hubble.gl/pull/4)
+- Refactor encoder settings and scene settings api [#8](https://github.com/uber/hubble.gl/pull/8)
   - scene settings are defined at scene load time, so you can set scene resolution and animation length there.
   - encoder settings are defined before every render, so you can set seek options there.
-- Gif Encoder #7
+- Gif Encoder [#7](https://github.com/uber/hubble.gl/pull/7)

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -6,7 +6,7 @@ Initial release.
 
 ## 1.1.0 (draft)
 
-- Encoders are constructed right before rendering starts, instead of when a scene is defined. [#1](https://github.com/uber/hubble.gl/pull/1)
+- Encoders are constructed right before rendering starts, instead of only when a scene is defined. [#1](https://github.com/uber/hubble.gl/pull/1)
 - DeckAdapter.render now accepts a onStop callback.
 - Remove stop and dispose from FrameEncoders [#3](https://github.com/uber/hubble.gl/pull/3)
 - Allow PNGEncoder transparent frames [#4](https://github.com/uber/hubble.gl/pull/4)

--- a/examples/minimal/app.js
+++ b/examples/minimal/app.js
@@ -14,7 +14,7 @@ const INITIAL_VIEW_STATE = {
 
 const adapter = new DeckAdapter(sceneBuilder);
 
-/** @type {import('@hubble.gl/core/src/types').EncoderSettings} */
+/** @type {import('@hubble.gl/core/src/types').FrameEncoderSettings} */
 const encoderSettings = {
   framerate: 30,
   webm: {

--- a/examples/minimal/app.js
+++ b/examples/minimal/app.js
@@ -14,9 +14,8 @@ const INITIAL_VIEW_STATE = {
 
 const adapter = new DeckAdapter(sceneBuilder);
 
+/** @type {import('@hubble.gl/core/src/types').EncoderSettings} */
 const encoderSettings = {
-  animationLengthMs: 15000,
-  startOffsetMs: 0,
   framerate: 30,
   webm: {
     quality: 0.8

--- a/examples/minimal/scene.js
+++ b/examples/minimal/scene.js
@@ -49,10 +49,17 @@ function getKeyframes(animationLoop, data) {
 }
 
 export async function sceneBuilder(animationLoop) {
-  const length = 5000;
   const data = await fetch(
     'https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/bart-lines.json'
   ).then(x => x.json());
   const keyframes = getKeyframes(animationLoop, data);
-  return new DeckScene({animationLoop, length, keyframes, data, renderLayers});
+  return new DeckScene({
+    animationLoop,
+    keyframes,
+    data,
+    renderLayers,
+    lengthMs: 5000,
+    width: 720,
+    height: 480
+  });
 }

--- a/examples/terrain/app.js
+++ b/examples/terrain/app.js
@@ -15,10 +15,9 @@ const INITIAL_VIEW_STATE = {
 
 const adapter = new DeckAdapter(sceneBuilder);
 
+/** @type {import('@hubble.gl/core/src/types').EncoderSettings} */
 const encoderSettings = {
-  animationLengthMs: 15000,
-  startOffsetMs: 0,
-  framerate: 30,
+  framerate: 10,
   webm: {
     quality: 0.8
   },
@@ -36,8 +35,6 @@ export default function App() {
   return (
     <div style={{position: 'relative'}}>
       <DeckGL
-        width={720}
-        height={480}
         ref={deckgl}
         initialViewState={INITIAL_VIEW_STATE}
         {...adapter.getProps(deckgl, setReady, nextFrame)}

--- a/examples/terrain/app.js
+++ b/examples/terrain/app.js
@@ -15,7 +15,7 @@ const INITIAL_VIEW_STATE = {
 
 const adapter = new DeckAdapter(sceneBuilder);
 
-/** @type {import('@hubble.gl/core/src/types').EncoderSettings} */
+/** @type {import('@hubble.gl/core/src/types').FrameEncoderSettings} */
 const encoderSettings = {
   framerate: 10,
   webm: {

--- a/examples/terrain/scene.js
+++ b/examples/terrain/scene.js
@@ -83,9 +83,17 @@ function getKeyframes(animationLoop, data) {
 }
 
 export const sceneBuilder = animationLoop => {
-  const length = 15000;
+  const lengthMs = 15000;
   const data = {};
   // set up keyframes
   const keyframes = getKeyframes(animationLoop, data);
-  return new DeckScene({animationLoop, length, keyframes, data, renderLayers});
+  return new DeckScene({
+    animationLoop,
+    keyframes,
+    data,
+    renderLayers,
+    lengthMs,
+    width: 720,
+    height: 480
+  });
 };

--- a/modules/core/docs/deck-adapter.md
+++ b/modules/core/docs/deck-adapter.md
@@ -3,7 +3,7 @@
 ## Constructor
 
 ```js
-new DeckAdapter(sceneBuilder, Encoder, encoderSettings);
+new DeckAdapter(sceneBuilder);
 ```
 
 ## Parameters
@@ -18,20 +18,12 @@ async function sceneBuilder(animationLoop) {
   const data = await fetch(...)
   const keyframes = {}
   const renderLayers = ...
-  const length = 5000 // ms
-  return new DeckScene({animationLoop, length, keyframes, data, renderLayers})
+  const lengthMs = 5000 // ms
+  const width = 1920 // px
+  const height = 1080 // px
+  return new DeckScene({animationLoop, keyframes, data, renderLayers, lengthMs, width, height})
 }
 ```
-
-##### `Encoder` (`typeof FrameEncoder`, Optional)
-
-* Default: `PreviewEncoder`
-
-FrameEncoder class for capturing deck canvas. See [Encoders]()
-
-##### `encoderSettings` (`FrameEncoderSettings`, Optional)
-
-* Default: `{}` (See `FrameEncoder` for internal defaults)
 
 ## Methods
 
@@ -47,25 +39,15 @@ Parameters:
 
 * `onNextFrame` (`(nextTimeMs: number) => void`) - Callback indicating the next frame in a rendering should be displayed.
 
-##### `update`
-
-Call in react render when recording to request a new frame.
-
-Parameters:
-
-* `onNextFrame` (`(nextTimeMs: number) => void`) - Callback indicating the next frame in a rendering should be displayed.
-
 ##### `render`
 
 Start rendering.
 
 Parameters:
 
-* `startTimeMs` (`number`, Optional) - Offset the animation. Defaults to 0.
+* `Encoder` (`typeof FrameEncoder`, Optional) - Default: `PreviewEncoder`. FrameEncoder class for capturing deck canvas. See [Encoders](/docs/encoder)
 
-##### `preview`
-
-Preview rendering.
+* `encoderSettings` (`FrameEncoderSettings`, Optional) - Default: `{}` (See [Encoder Overview](/docs/encoder) for internal defaults)
 
 ##### `stop`
 

--- a/modules/core/docs/encoder/README.md
+++ b/modules/core/docs/encoder/README.md
@@ -1,5 +1,17 @@
 # Overview
 
+### FrameEncoderSettings
+
+* `startOffsetMs` (`number`, Optional) - Offset the animation. Defaults to 0.
+
+* `durationMs` (`number`, Optional) - Set to render a smaller duration than the whole clip. Defaults to scene length.  
+  
+* `filename`(`string`, Optional) - Filename for rendered video. Defaults to UUID.
+
+* `framerate` (`number`, Optional) - framerate of rendered video. Defaults to 30.
+
+See encoders for additional namespaced settings.
+
 ##### Video
 
 All encoder classes implement the [`Encoder`]() abstract class and inherit from the [`FrameEncoder`]() or [`TarEncoder`]() base classes.

--- a/modules/core/docs/encoder/jpeg-sequence-encoder.md
+++ b/modules/core/docs/encoder/jpeg-sequence-encoder.md
@@ -2,6 +2,12 @@
 
 A photo sequence encoder that inherits [TarEncoder](). Saves each frame as a photo contained in a `".tar"` archive.
 
+## FrameEncoderSettings
+
+In addition to the top level [FrameEncoderSettings](/docs/encoder), these settings are available under the `jpeg` namespace.
+
+* `quality` - See member note. Defaults to 0.8. 
+
 ## Members
 
 * `extension` - `".jpeg"`

--- a/modules/core/docs/encoder/webm-encoder.md
+++ b/modules/core/docs/encoder/webm-encoder.md
@@ -2,6 +2,12 @@
 
 A WebM video format encoder that inherits [FrameEncoder]().
 
+## FrameEncoderSettings
+
+In addition to the top level [FrameEncoderSettings](/docs/encoder), these settings are available under the `webm` namespace.
+
+* `quality` - See member note. Defaults to 0.8. 
+
 ## Members
 
 * `extension` - `".webm"`

--- a/modules/core/src/capture/video-capture.js
+++ b/modules/core/src/capture/video-capture.js
@@ -25,14 +25,16 @@ import {FrameEncoder} from '../encoders';
 import {guid} from './utils';
 
 export class VideoCapture {
-  /** @type {number} */
-  recordingLengthMs;
   /** @type {boolean} */
   recording;
   /** @type {boolean} */
   capturing;
   /** @type {number} */
   timeMs;
+  /** @type {number} */
+  endTimeMs;
+  /** @type {number} */
+  durationMs;
   /** @type {number} */
   framerate;
   /** @type {FrameEncoder} */
@@ -55,7 +57,11 @@ export class VideoCapture {
     this.save = this.save.bind(this);
   }
 
-  parseEncoderSettings(encoderSettings) {
+  /**
+   * @param {import('types').FrameEncoderSettings} encoderSettings
+   * @param {number} sceneLengthMs
+   */
+  parseEncoderSettings(encoderSettings, sceneLengthMs) {
     const parsedSettings = encoderSettings;
 
     if (!parsedSettings.startOffsetMs) {
@@ -63,17 +69,28 @@ export class VideoCapture {
     }
     this.timeMs = parsedSettings.startOffsetMs;
 
+    if (parsedSettings.durationMs) {
+      this.endTimeMs = parsedSettings.startOffsetMs + parsedSettings.durationMs;
+    } else {
+      parsedSettings.durationMs = sceneLengthMs - parsedSettings.startOffsetMs;
+      this.endTimeMs = sceneLengthMs;
+    }
+    if (this.endTimeMs > sceneLengthMs) {
+      throw new Error(
+        `Recording end time (${this.endTimeMs}) cannot be greater then scene length (${sceneLengthMs})`
+      );
+    }
+    if (parsedSettings.durationMs <= 0) {
+      throw new Error(
+        `Invalid recording length in ms (${parsedSettings.durationMs}).  Must be greater than 0.`
+      );
+    }
+    this.durationMs = parsedSettings.durationMs;
+
     if (!parsedSettings.filename) {
       parsedSettings.filename = guid();
     }
     this.filename = parsedSettings.filename;
-
-    if (parsedSettings.animationLengthMs <= 0) {
-      throw new Error(
-        `Invalid recording length in ms (${parsedSettings.animationLengthMs}).  Must be greater than 0.`
-      );
-    }
-    this.recordingLengthMs = parsedSettings.animationLengthMs;
 
     return parsedSettings;
   }
@@ -85,14 +102,16 @@ export class VideoCapture {
 
   /**
    * Start recording.
-   *  @param {typeof FrameEncoder} Encoder
-   *  @param {import('types').FrameEncoderSettings} encoderSettings
+   * @param {typeof FrameEncoder} Encoder
+   * @param {import('types').FrameEncoderSettings} encoderSettings
+   * @param {number} sceneLengthMs
+   * @param {() => void} onStop
    */
-  render(Encoder, encoderSettings, onStop = undefined) {
+  render(Encoder, encoderSettings, sceneLengthMs, onStop = undefined) {
     if (!this.isRecording()) {
-      encoderSettings = this.parseEncoderSettings(encoderSettings);
+      encoderSettings = this.parseEncoderSettings(encoderSettings, sceneLengthMs);
 
-      console.log(`Starting recording for ${this.recordingLengthMs}ms.`);
+      console.log(`Starting recording for ${this.durationMs}ms.`);
       this.onStop = onStop;
       this.encoder = new Encoder(encoderSettings);
       this.recording = true;
@@ -135,7 +154,7 @@ export class VideoCapture {
    */
   stop(callback = undefined) {
     if (this.isRecording()) {
-      console.log(`Stopping recording.  Recorded for ${this.recordingLengthMs}ms.`);
+      console.log(`Stopping recording.  Recorded for ${this.durationMs}ms.`);
       this.recording = false;
       this.save();
 
@@ -187,7 +206,7 @@ export class VideoCapture {
   _step() {
     // generating next frame timestamp
     this.timeMs = this._getNextTimeMs();
-    if (this.timeMs > this.recordingLengthMs) {
+    if (this.timeMs > this.endTimeMs) {
       return {kind: 'error', error: 'STOP'};
     }
     return {kind: 'step', nextTimeMs: this.timeMs};

--- a/modules/core/src/scene/deck-scene.js
+++ b/modules/core/src/scene/deck-scene.js
@@ -19,13 +19,15 @@
 // THE SOFTWARE.
 export default class DeckScene {
   /** @param {import('types').DeckSceneParams} params */
-  constructor({animationLoop, length, keyframes, data, renderLayers}) {
+  constructor({animationLoop, keyframes, data, renderLayers, lengthMs, width, height}) {
     this.animationLoop = animationLoop;
     this.keyframes = keyframes;
     this.data = data;
     this._renderLayers = renderLayers;
-    this.length = length;
     this.renderLayers = this.renderLayers.bind(this);
+    this.lengthMs = lengthMs;
+    this.width = width;
+    this.height = height;
   }
 
   renderLayers() {

--- a/modules/core/src/scene/kepler-scene.js
+++ b/modules/core/src/scene/kepler-scene.js
@@ -19,14 +19,16 @@
 // THE SOFTWARE.
 export default class KeplerScene {
   /** @param {import('types').KeplerSceneParams} params */
-  constructor({animationLoop, length, keyframes, data, filters, getFrame}) {
+  constructor({animationLoop, keyframes, data, filters, getFrame, lengthMs, width, height}) {
     this.animationLoop = animationLoop;
     this.keyframes = keyframes;
     this.data = data;
     this._getFrame = getFrame;
     this.filters = filters;
-    this.length = length;
     this.getFrame = this.getFrame.bind(this);
+    this.lengthMs = lengthMs;
+    this.width = width;
+    this.height = height;
   }
 
   /**

--- a/modules/core/src/types.d.ts
+++ b/modules/core/src/types.d.ts
@@ -24,8 +24,8 @@ type DeckGl = {
 type FrameEncoderSettings = Partial<EncoderSettings>
 
 interface EncoderSettings {
-  animationLengthMs: number
-  startOffsetMs: number
+  startOffsetMs?: number
+  durationMs?: number  
   filename: string
   framerate: number
   jpeg: {
@@ -46,7 +46,9 @@ interface EncoderSettings {
 
 interface DeckSceneParams {
   animationLoop: any
-  length: number
+  lengthMs: number
+  width: number
+  height: number
   keyframes: any
   data: any
   renderLayers: (scene: DeckScene) => any[]
@@ -54,7 +56,9 @@ interface DeckSceneParams {
 
 interface KeplerSceneParams {
   animationLoop: any
-  length: number
+  lengthMs: number
+  width: number
+  height: number
   keyframes: any[]
   data: any
   filters: any[]

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "hubble.gl",
-  "version": "1.0.0",
-  "private": false,
+  "version": "1.1.0",
+  "private": "true",
   "description": "Hubble.gl is a powerful open source animation tool for large-scale data sets.",
   "repository": "https://github.com/uber/hubble.gl.git",
   "author": "Chris Gervang <chr@uber.com>",
   "license": "MIT",
-  "private": "true",
   "scripts": {
     "bootstrap": "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn && ocular-bootstrap",
     "checkjs": "tsc --noEmit --allowJs --checkJs --target ES5 src/*.js",


### PR DESCRIPTION
- scene settings are defined at scene load time, so you can set scene resolution and animation length there.
```ts
interface DeckSceneParams {
  lengthMs: number
  width: number
  height: number
  animationLoop: any
  keyframes: any
  data: any
  renderLayers: (scene: DeckScene) => any[]
}
```
- encoder settings are defined before every render, so you  can set seek options there.
```ts
interface EncoderSettings {
  startOffsetMs?: number
  durationMs?: number  
  filename: string
  framerate: number
  jpeg: {
    quality: number
  },
  webm: {
    quality: number
  }
}
```