### PR TITLE
Adding a ResolutionGuide component.

### DIFF
--- a/examples/camera/app.js
+++ b/examples/camera/app.js
@@ -1,7 +1,7 @@
 import React, {useState, useRef} from 'react';
 import DeckGL from '@deck.gl/react';
 import {DeckAdapter} from '@hubble.gl/core';
-import {useNextFrame, BasicControls} from '@hubble.gl/react';
+import {useNextFrame, BasicControls, ResolutionGuide} from '@hubble.gl/react';
 import {sceneBuilder} from './scene';
 import {layers} from './layers';
 import {vignette, fxaa} from '@luma.gl/shadertools';
@@ -42,9 +42,10 @@ export default function App() {
 
   return (
     <div style={{position: 'relative'}}>
+      <div style={{position: 'absolute'}}>
+        <ResolutionGuide />
+      </div>
       <DeckGL
-        width={720}
-        height={480}
         ref={deckgl}
         initialViewState={INITIAL_VIEW_STATE}
         parameters={{

--- a/examples/camera/scene.js
+++ b/examples/camera/scene.js
@@ -30,7 +30,7 @@ export async function sceneBuilder(animationLoop) {
     animationLoop,
     keyframes,
     lengthMs: 5000,
-    width: 720,
+    width: 640,
     height: 480
   });
 }

--- a/examples/terrain/app.js
+++ b/examples/terrain/app.js
@@ -2,7 +2,7 @@ import React, {useState, useRef} from 'react';
 import DeckGL from '@deck.gl/react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import {DeckAdapter} from 'hubble.gl';
-import {useNextFrame, BasicControls} from '@hubble.gl/react';
+import {useNextFrame, BasicControls, ResolutionGuide} from '@hubble.gl/react';
 import {sceneBuilder} from './scene';
 
 const INITIAL_VIEW_STATE = {
@@ -37,6 +37,9 @@ export default function App() {
 
   return (
     <div style={{position: 'relative'}}>
+      <div style={{position: 'absolute'}}>
+        <ResolutionGuide />
+      </div>
       <DeckGL
         ref={deckgl}
         initialViewState={INITIAL_VIEW_STATE}

--- a/examples/terrain/scene.js
+++ b/examples/terrain/scene.js
@@ -93,7 +93,7 @@ export const sceneBuilder = animationLoop => {
     data,
     renderLayers,
     lengthMs,
-    width: 720,
+    width: 640,
     height: 480
   });
 };

--- a/modules/react/src/components/index.js
+++ b/modules/react/src/components/index.js
@@ -19,3 +19,4 @@
 // THE SOFTWARE.
 export {default as BasicControls} from './basic-controls';
 export {default as EncoderDropdown} from './encoder-dropdown';
+export {default as ResolutionGuide} from './resolution-guide';

--- a/modules/react/src/components/resolution-guide.js
+++ b/modules/react/src/components/resolution-guide.js
@@ -18,5 +18,37 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-export {EncoderDropdown, BasicControls, ResolutionGuide} from './components';
-export {useNextFrame} from './hooks';
+import React from 'react';
+
+export default function ResolutionGuide() {
+  return (
+    <div style={{position: 'relative'}}>
+      <Outline width={2560} height={1440} name={'2160p, 2K'} />
+      <Outline width={2560} height={1440} name={'1440p'} />
+      <Outline width={1920} height={1080} name={'1080p, Full HD'} />
+      <Outline width={1280} height={720} name={'720p, HD'} />
+      <Outline width={854} height={480} name={'480p, WSD'} />
+      <Outline width={640} height={480} name={'480p, SD'} />
+      <Outline width={640} height={360} name={'360p'} />
+      <Outline width={426} height={240} name={'240p'} />
+    </div>
+  );
+}
+
+function Outline({width, height, name}) {
+  return (
+    <div style={{position: 'absolute', width, height, outline: '2px dashed black'}}>
+      <div
+        style={{
+          position: 'absolute',
+          bottom: -20,
+          right: 0,
+          fontSize: '14px',
+          font: "normal 14px/20px 'Uber Move',Helvetica,Arial,sans-serif"
+        }}
+      >
+        {name} ({width} x {height})
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Adding this to examples so the background doesn't look so empty, and shipping in `@hubble.gl/react` for reuse.
<img width="1609" alt="Screen Shot 2020-07-13 at 1 16 19 PM" src="https://user-images.githubusercontent.com/2461547/87349420-1c664d00-c50b-11ea-95e6-54429ec044fe.png">
