### PR TITLE
Remove kepler.gl recursive includes

### DIFF
--- a/examples/camera/package.json
+++ b/examples/camera/package.json
@@ -5,8 +5,10 @@
     "clean": "rm -rf yarn.lock ./node_modules",
     "bootstrap": "yarn clean && yarn"
   },
+  "peerDependencies": {
+    "@luma.gl/debug": "^8.2.0"
+  },
   "dependencies": {
-    "@luma.gl/debug": "^8.3.1",
     "d3-color": "^1.4.1"
   },
   "devDependencies": {

--- a/examples/kepler-integration/package.json
+++ b/examples/kepler-integration/package.json
@@ -5,12 +5,13 @@
     "clean": "rm -rf yarn.lock ./node_modules",
     "bootstrap": "yarn clean && yarn"
   },
+  "peerDependencies": {
+    "@luma.gl/debug": "^8.2.0"
+  },
   "dependencies": {
-    "@luma.gl/debug": "^8.3.1",
     "d3-request": "^1.0.6",
     "global": "^4.3.0",
     "hubble.gl": "^1.1.0",
-    "react-intl": "^3.12.0",
     "react-map-gl": "^5.2.10",
     "react-markdown": "^4.2.2",
     "react-palm": "^3.3.6",

--- a/examples/kepler-integration/src/app.js
+++ b/examples/kepler-integration/src/app.js
@@ -23,6 +23,8 @@ import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
 import styled, {ThemeProvider} from 'styled-components';
 import window from 'global/window';
 import {connect} from 'react-redux';
+import {IntlProvider} from 'react-intl';
+import {messages} from 'kepler.gl/localization';
 import {theme} from 'kepler.gl/styles';
 import {replaceLoadDataModal} from './factories/load-data-modal';
 import {replaceMapControl} from './factories/map-control';
@@ -161,38 +163,40 @@ class App extends Component {
 
   render() {
     return (
-      <ThemeProvider theme={theme}>
-        <GlobalStyle
-          // this is to apply the same modal style as kepler.gl core
-          // because styled-components doesn't always return a node
-          // https://github.com/styled-components/styled-components/issues/617
-          ref={node => {
-            if (node) {
-              this.root = node;
-            }
-          }}
-        >
-          <WindowSize>
-            <ExportVideo />
-            <div style={{transition: 'margin 1s, height 1s', flex: 1}}>
-              <AutoSizer>
-                {({height, width}) => (
-                  <KeplerGl
-                    mapboxApiAccessToken={AUTH_TOKENS.MAPBOX_TOKEN}
-                    id="map"
-                    /*
-                     * Specify path to keplerGl state, because it is not mount at the root
-                     */
-                    getState={keplerGlGetState}
-                    width={width}
-                    height={height}
-                  />
-                )}
-              </AutoSizer>
-            </div>
-          </WindowSize>
-        </GlobalStyle>
-      </ThemeProvider>
+      <IntlProvider locale="en" messages={messages.en}>
+        <ThemeProvider theme={theme}>
+          <GlobalStyle
+            // this is to apply the same modal style as kepler.gl core
+            // because styled-components doesn't always return a node
+            // https://github.com/styled-components/styled-components/issues/617
+            ref={node => {
+              if (node) {
+                this.root = node;
+              }
+            }}
+          >
+            <WindowSize>
+              <ExportVideo />
+              <div style={{transition: 'margin 1s, height 1s', flex: 1}}>
+                <AutoSizer>
+                  {({height, width}) => (
+                    <KeplerGl
+                      mapboxApiAccessToken={AUTH_TOKENS.MAPBOX_TOKEN}
+                      id="map"
+                      /*
+                       * Specify path to keplerGl state, because it is not mount at the root
+                       */
+                      getState={keplerGlGetState}
+                      width={width}
+                      height={height}
+                    />
+                  )}
+                </AutoSizer>
+              </div>
+            </WindowSize>
+          </GlobalStyle>
+        </ThemeProvider>
+      </IntlProvider>
     );
   }
 }

--- a/examples/trips/package.json
+++ b/examples/trips/package.json
@@ -5,9 +5,11 @@
     "clean": "rm -rf yarn.lock ./node_modules",
     "bootstrap": "yarn clean && yarn"
   },
+  "peerDependencies": {
+    "@luma.gl/debug": "^8.2.0",
+    "@luma.gl/shadertools": "^8.2.0"
+  },
   "dependencies": {
-    "@luma.gl/debug": "^8.3.1",
-    "@luma.gl/shadertools": "^8.3.1",
     "d3-color": "^1.4.1",
     "react-map-gl": "^5.0.0"
   },

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -29,10 +29,12 @@
     "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
+  "peerDependencies": {
+    "@luma.gl/engine": "^8.2.0"
+  },
   "dependencies": {
     "@loaders.gl/core": "^2.1.6",
     "@loaders.gl/video": "2.2.0-alpha.1",
-    "@luma.gl/engine": "^8.3.1",
     "downloadjs": "^1.4.7",
     "popmotion": "^8.6.10",
     "webm-writer": "^0.2.2"

--- a/modules/react/src/components/export-video/constants.js
+++ b/modules/react/src/components/export-video/constants.js
@@ -27,6 +27,8 @@ export const DEFAULT_SETTINGS_WIDTH = 280;
 
 export const DEFAULT_FILENAME = 'kepler.gl';
 
+export const SIDEPANEL_WIDTH = 300;
+
 export const FORMATS = [
   {
     value: 'gif',

--- a/modules/react/src/components/export-video/export-video-modal.js
+++ b/modules/react/src/components/export-video/export-video-modal.js
@@ -23,7 +23,7 @@ import React, {Component, createRef} from 'react';
 import Modal from 'react-modal';
 import styled, {ThemeProvider} from 'styled-components';
 import {createSelector} from 'reselect';
-import {DIMENSIONS} from 'kepler.gl/constants';
+import {SIDEPANEL_WIDTH} from './constants';
 
 const ModalContainer = styled.div`
   position: relative;
@@ -70,7 +70,7 @@ class ExportVideoModal extends Component {
       content: {
         top: 'auto',
         left: 'auto',
-        right: `calc(50% - ${DIMENSIONS.sidePanel.width / 2}px)`,
+        right: `calc(50% - ${SIDEPANEL_WIDTH / 2}px)`,
         bottom: '50%',
         transform: 'translate(50%, 50%)',
         padding: '0px 0px 0px 0px',

--- a/modules/react/src/components/export-video/export-video-panel-settings.js
+++ b/modules/react/src/components/export-video/export-video-panel-settings.js
@@ -128,7 +128,6 @@ const ExportVideoPanelSettings = ({
               style={{width: '100%', marginLeft: '0px'}}
               className="modal-duration__slider"
             >
-              {/* TODO onSlider1Change */}
               <Slider
                 showValues={false}
                 enableBarDrag={true}

--- a/modules/react/src/components/export-video/export-video-panel.js
+++ b/modules/react/src/components/export-video/export-video-panel.js
@@ -20,9 +20,6 @@
 
 import React from 'react';
 import styled, {withTheme} from 'styled-components';
-import {IntlProvider} from 'react-intl';
-
-import {messages} from 'kepler.gl/localization';
 
 import {
   DEFAULT_PADDING,
@@ -143,38 +140,36 @@ const ExportVideoPanel = ({
   setDuration
 }) => {
   return (
-    <IntlProvider locale="en" messages={messages.en}>
-      <Panel exportVideoWidth={exportVideoWidth} className="export-video-panel">
-        {header !== false ? (
-          <>
-            <PanelClose handleClose={handleClose} />
-            <StyledTitle className="export-video-panel__title">Export Video</StyledTitle>
-          </>
-        ) : null}
-        <PanelBody
-          exportVideoWidth={exportVideoWidth}
-          mapData={mapData}
-          adapter={adapter}
-          setMediaType={setMediaType}
-          setCameraPreset={setCameraPreset}
-          setFileName={setFileName}
-          setResolution={setResolution}
-          settingsData={settingsData}
-          setViewState={setViewState}
-          durationMs={durationMs}
-          frameRate={frameRate}
-          resolution={resolution}
-          mediaType={mediaType}
-          viewState={viewState}
-          setDuration={setDuration}
-        />
-        <ExportVideoPanelFooter
-          handleClose={handleClose}
-          handlePreviewVideo={handlePreviewVideo}
-          handleRenderVideo={handleRenderVideo}
-        />
-      </Panel>
-    </IntlProvider>
+    <Panel exportVideoWidth={exportVideoWidth} className="export-video-panel">
+      {header !== false ? (
+        <>
+          <PanelClose handleClose={handleClose} />
+          <StyledTitle className="export-video-panel__title">Export Video</StyledTitle>
+        </>
+      ) : null}
+      <PanelBody
+        exportVideoWidth={exportVideoWidth}
+        mapData={mapData}
+        adapter={adapter}
+        setMediaType={setMediaType}
+        setCameraPreset={setCameraPreset}
+        setFileName={setFileName}
+        setResolution={setResolution}
+        settingsData={settingsData}
+        setViewState={setViewState}
+        durationMs={durationMs}
+        frameRate={frameRate}
+        resolution={resolution}
+        mediaType={mediaType}
+        viewState={viewState}
+        setDuration={setDuration}
+      />
+      <ExportVideoPanelFooter
+        handleClose={handleClose}
+        handlePreviewVideo={handlePreviewVideo}
+        handleRenderVideo={handleRenderVideo}
+      />
+    </Panel>
   );
 };
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "@deck.gl/mapbox": "^8.2.0",
     "@loaders.gl/json": "^2.3.3",
     "@loaders.gl/video": "^2.3.3",
+    "@luma.gl/debug": "^8.2.0",
     "@luma.gl/engine": "^8.2.0",
+    "@luma.gl/shadertools": "^8.2.0",
     "@probe.gl/bench": "^3.2.1",
     "@probe.gl/test-utils": "^3.2.1",
     "babel-eslint": "^9.0.0",
@@ -76,7 +78,9 @@
     "styled-components": "^4.4.1"
   },
   "resolutions": {
+    "@deck.gl/aggregation-layers": "8.2.0",
     "@deck.gl/core": "8.2.0",
+    "@deck.gl/extensions": "8.2.0",
     "@deck.gl/geo-layers": "8.2.0",
     "@deck.gl/mesh-layers": "8.2.0",
     "@deck.gl/layers": "8.2.0",
@@ -84,6 +88,7 @@
     "@deck.gl/mapbox": "8.2.0",
     "@luma.gl/constants": "8.2.0",
     "@luma.gl/core": "8.2.0",
+    "@luma.gl/debug": "8.2.0",
     "@luma.gl/engine": "8.2.0",
     "@luma.gl/gltools": "8.2.0",
     "@luma.gl/experimental": "8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1121,13 +1121,13 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@deck.gl/aggregation-layers@^8.2.0":
-  version "8.3.6"
-  resolved "https://registry.yarnpkg.com/@deck.gl/aggregation-layers/-/aggregation-layers-8.3.6.tgz#d68f8bb6aa7950f3d23942c6fcec4be5c6ddcad5"
-  integrity sha512-aj8CkFfCTfqdUd6VRZKQ4/langmUm5Q7/OCnUYt+a8Flm1hLsflKHSxcIJupsV/4dg8gfyWZqf+/wzd9PkeGVQ==
+"@deck.gl/aggregation-layers@8.2.0", "@deck.gl/aggregation-layers@^8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@deck.gl/aggregation-layers/-/aggregation-layers-8.2.0.tgz#344972ae9ec6ec6d66137ebdad768c789c4150aa"
+  integrity sha512-lddj84nJnXnHljVgwT39ePvR0t4ahCJtloBQTwjvByJAuDOynO8S6QOY23UNr9jd0jCC724xZiEZIlJki6iWCw==
   dependencies:
-    "@luma.gl/shadertools" "^8.3.1"
-    "@math.gl/web-mercator" "^3.3.0"
+    "@luma.gl/shadertools" "^8.2.0"
+    "@math.gl/web-mercator" "^3.2.1"
     d3-hexbin "^0.2.1"
 
 "@deck.gl/core@8.2.0", "@deck.gl/core@^8.2.0":
@@ -1144,12 +1144,12 @@
     mjolnir.js "^2.3.0"
     probe.gl "^3.2.1"
 
-"@deck.gl/extensions@^8.2.0":
-  version "8.3.6"
-  resolved "https://registry.yarnpkg.com/@deck.gl/extensions/-/extensions-8.3.6.tgz#ecc86888c2a69695293c3b64196cc2d6e863f001"
-  integrity sha512-LBqp3ygTeODG0xRLDRUrrI4UpTliT/Zo/D1BVJ5B4zbg6O3XXe2lgpZlCo+JCJ0KgkkSWAtsgOJm91quRVCgPw==
+"@deck.gl/extensions@8.2.0", "@deck.gl/extensions@^8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@deck.gl/extensions/-/extensions-8.2.0.tgz#c5d163aff758c6eb3eca46a208533a23157fab5c"
+  integrity sha512-sp7w7xwxeXxEpLeBKlMgmDfDo5lUs7RfuTfOQNfBSoCARUd0Dr2FEm//T2uRPjejvI4eLNTqvXGKr3tHV/v2ww==
   dependencies:
-    "@luma.gl/shadertools" "^8.3.1"
+    "@luma.gl/shadertools" "^8.2.0"
 
 "@deck.gl/geo-layers@8.2.0", "@deck.gl/geo-layers@^8.2.0":
   version "8.2.0"
@@ -2274,7 +2274,18 @@
     "@luma.gl/shadertools" "8.2.0"
     "@luma.gl/webgl" "8.2.0"
 
-"@luma.gl/engine@8.2.0", "@luma.gl/engine@^8.2.0", "@luma.gl/engine@^8.3.1":
+"@luma.gl/debug@8.2.0", "@luma.gl/debug@^8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@luma.gl/debug/-/debug-8.2.0.tgz#1cca784b162b31808c7c34e850eb18a7a35ede9b"
+  integrity sha512-sfcknRq32TaD1FTsU3a2VGgBGAalSjZEh0Kpf2Lid0RT4bib3pkX1IwK4kTl7SI7nc7gxjvcSpAXwmi1aoo3zA==
+  dependencies:
+    "@luma.gl/constants" "8.2.0"
+    glsl-transpiler "^1.8.5"
+    math.gl "^3.2.1"
+    probe.gl "^3.2.1"
+    webgl-debug "^2.0.1"
+
+"@luma.gl/engine@8.2.0", "@luma.gl/engine@^8.2.0":
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/@luma.gl/engine/-/engine-8.2.0.tgz#e598b723639619e00cff8acaf4af39de4d9fb61f"
   integrity sha512-HxlwU66TCJzMCY+wuxiyapiGFEp0HrRqg2m2fj8K5h5PBYMjDZSrs2JuDoOz97oFVALfujAEw74OX9pFr5uiRg==
@@ -2305,7 +2316,7 @@
     "@luma.gl/constants" "8.2.0"
     probe.gl "^3.2.1"
 
-"@luma.gl/shadertools@8.2.0", "@luma.gl/shadertools@^8.2.0", "@luma.gl/shadertools@^8.3.1":
+"@luma.gl/shadertools@8.2.0", "@luma.gl/shadertools@^8.2.0":
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/@luma.gl/shadertools/-/shadertools-8.2.0.tgz#91f768d21d6c41a0da387d770f09a2c9596b0395"
   integrity sha512-A6dW/imkMucE0hVp/nXnhlaZ8MCkQy7rXBNCGwMq6rdNYLBNZg5f0zAWssam/YxENWVnhhpHzqg6PCEMyC9cWw==
@@ -3241,7 +3252,7 @@ array-flatten@1.1.1:
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
 
-array-flatten@^2.1.0:
+array-flatten@^2.0.0, array-flatten@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.2.tgz#24ef80a28c1a893617e2149b0c6d0d788293b099"
   integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
@@ -3460,6 +3471,11 @@ bail@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.5.tgz#b6fa133404a392cbc1f8c4bf63f5953351e7a776"
   integrity sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==
+
+balanced-match@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.3.0.tgz#a91cdd1ebef1a86659e70ff4def01625fc2d6756"
+  integrity sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y=
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -5481,6 +5497,11 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escaper@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/escaper/-/escaper-2.5.3.tgz#8b8fe90ba364054151ab7eff18b4ce43b1e13ab5"
+  integrity sha512-QGb9sFxBVpbzMggrKTX0ry1oiI4CSDAl9vIL702hzl1jGW8VZs7qfqTRX7WDOjoNDoEVGcEtu1ZOQgReSfT2kQ==
+
 eslint-config-prettier@^6.3.0, eslint-config-prettier@^6.7.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz#f6d2238c1290d01c859a8b5c1f7d352a0b0da8b1"
@@ -5878,6 +5899,13 @@ express@^4.16.3, express@^4.17.1:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+expression-eval@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/expression-eval/-/expression-eval-1.4.0.tgz#3e250c110ff9bb6606d0c8ad0ecb9600e388f76d"
+  integrity sha512-CvpqG2feKjGcr+6NB/ZOA2csOeVL+2DSiWrF/4h0mrdYv4SxR2vCZhLHSst4Sp+xHtN/LQtPfi6i7K9EJwzRGw==
+  dependencies:
+    jsep "^0.3.0"
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -6127,6 +6155,11 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+float-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/float-regex/-/float-regex-1.0.0.tgz#f80fa91d672c6b924842034bd87a0dd72069d2ef"
+  integrity sha1-+A+pHWcsa5JIQgNL2HoN1yBp0u8=
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -6578,6 +6611,36 @@ globby@^9.2.0:
     ignore "^4.0.3"
     pify "^4.0.1"
     slash "^2.0.0"
+
+glsl-parser@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/glsl-parser/-/glsl-parser-2.0.1.tgz#3ffac4ee05cc4d8141fd6b1e41e82b3766ff61b9"
+  integrity sha512-hcPQtfz0AtxkyooSvim0RsHFNsiHXTY80GX2GtoTpFTImxW3cOINpb0cY6HFKnYkbheQRM7cDzCzzItNT6ZSiA==
+  dependencies:
+    glsl-tokenizer "^2.1.4"
+    through "2.3.4"
+    through2 "^0.6.3"
+
+glsl-tokenizer@^2.1.4, glsl-tokenizer@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz#1c2e78c16589933c274ba278d0a63b370c5fee1a"
+  integrity sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==
+  dependencies:
+    through2 "^0.6.3"
+
+glsl-transpiler@^1.8.5:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/glsl-transpiler/-/glsl-transpiler-1.8.5.tgz#e25477109a7a538f3e24ba422c1af6fcd0556f14"
+  integrity sha512-A9KWeznPGsKblXDgByDmzbzYh3ILpIVXSYA81n0+uT9VdGpnFKFsb42ziBZtjNHotINiM4lRVajCYfoRFoYCLA==
+  dependencies:
+    array-flatten "^2.0.0"
+    float-regex "^1.0.0"
+    glsl-parser "^2.0.1"
+    glsl-tokenizer "^2.1.5"
+    inherits "^2.0.1"
+    pick-by-alias "^1.2.0"
+    prepr "^1.1.2"
+    xtend "^4.0.1"
 
 got@^5.0.0:
   version "5.7.1"
@@ -7705,6 +7768,11 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
+
+jsep@^0.3.0:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/jsep/-/jsep-0.3.5.tgz#3fd79ebd92f6f434e4857d5272aaeef7d948264d"
+  integrity sha512-AoRLBDc6JNnKjNcmonituEABS5bcfqDhQAWWXNTFrqu6nVXBpBAGfcoTGZMFlIrh9FjmE1CQyX9CTNwZrXMMDA==
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -9510,6 +9578,11 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parenthesis@^3.0.0:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/parenthesis/-/parenthesis-3.1.7.tgz#01c89b603a2a6a262ec47554e74ed154a9be2aa6"
+  integrity sha512-iMtu+HCbLXVrpf6Ys/4YKhcFxbux3xK4ZVB9r+a2kMSqeeQWQoDNYlXIsOjwlT2ldYXZ3k5PVeBnYn7fbAo/Bg==
+
 parse-asn1@^5.0.0, parse-asn1@^5.1.5:
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.5.tgz#003271343da58dc94cace494faef3d2147ecea0e"
@@ -9706,6 +9779,11 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+pick-by-alias@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pick-by-alias/-/pick-by-alias-1.2.0.tgz#5f7cb2b1f21a6e1e884a0c87855aa4a37361107b"
+  integrity sha1-X3yysfIabh6ISgyHhVqko3NhEHs=
+
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
@@ -9845,6 +9923,18 @@ prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
+
+prepr@^1.1.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/prepr/-/prepr-1.2.4.tgz#ced95f540ae1a9b62863d0c551271252cc415556"
+  integrity sha512-g2TAN/rTgSpr30qb8UlhqHGK+oGTRr2cCWOI+DRs2Px4/e5jg1db2QDbux/WOK9uMiSPfoi5ZGOvn6lFSu8jeg==
+  dependencies:
+    balanced-match "^0.3.0"
+    escaper "^2.5.3"
+    expression-eval "^1.4.0"
+    object-assign "^4.1.1"
+    parenthesis "^3.0.0"
+    strip-json-comments "^2.0.1"
 
 prettier-check@2.0.0:
   version "2.0.0"
@@ -10542,7 +10632,7 @@ read@1, read@~1.0.1:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@~1.0.33-1:
+"readable-stream@>=1.0.33-1 <1.1.0-0", readable-stream@~1.0.33-1:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
   integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
@@ -12011,6 +12101,14 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
+through2@^0.6.3:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
+  integrity sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=
+  dependencies:
+    readable-stream ">=1.0.33-1 <1.1.0-0"
+    xtend ">=4.0.0 <4.1.0-0"
+
 through2@^2.0.0, through2@^2.0.2:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
@@ -12030,6 +12128,11 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8,
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+through@2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.4.tgz#495e40e8d8a8eaebc7c275ea88c2b8fc14c56455"
+  integrity sha1-SV5A6Nio6uvHwnXqiMK4/BTFZFU=
 
 thunky@^1.0.2:
   version "1.1.0"
@@ -12704,6 +12807,11 @@ web-streams-polyfill@^3.0.0:
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.0.0.tgz#c8bcb1e2ec1820088ca201674486a0f1feae848b"
   integrity sha512-tcZlIJ+VBxuDXdRFF3PCZTJ3yUISGklG4hkl3CDGOlZ8XwpN90L5YsJNoSPH72wZ4nbsatE/OfIaxfM3p+6W7w==
 
+webgl-debug@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/webgl-debug/-/webgl-debug-2.0.1.tgz#dc11bea3d947764bce061fdb5a23109c13787c95"
+  integrity sha512-G7BOpMmqdc31X1nb3eqwVxw/v1MNV/ulgw7Bs+7+a/sn+fC0d0OiMkerA55C6+3BL2vULyJ3kZLPcEL5GbXzhw==
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
@@ -13048,7 +13156,7 @@ xregexp@^4.3.0:
   dependencies:
     "@babel/runtime-corejs3" "^7.8.3"
 
-xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
- Remove kepler.gl/ includes from react components entirely
  - Replace `DIMENSIONS` from `kepler.gl/constants` with the single constant we use. This is fixed in kepler.gl anyway.
  - Move ReactIntl integration to `kepler-integration` example to remove `kepler.gl/localization` dependency from component. This context is already provided inside kepler.gl.
- Move luma.gl to a peer dependency of the sub-packages to avoid version conflicts with examples
- Move `react-intl` dep to top level to avoid duplicated intl context instances in example
- Pin more luma/deck versions to 8.2.0 to match kepler