### PR TITLE
Rendering feedback - Spinner

### DIFF
--- a/examples/kepler-integration/src/components/export-video.js
+++ b/examples/kepler-integration/src/components/export-video.js
@@ -25,7 +25,7 @@ import styled, {withTheme} from 'styled-components';
 import {InjectKeplerUI, ExportVideoModal, ExportVideoPanelContainer} from '@hubble.gl/react';
 
 // Hook up mutual kepler imports
-import {Button, Icons, Input, ItemSelector, Slider} from 'kepler.gl/components';
+import {Button, Icons, Input, ItemSelector, Slider, LoadingSpinner} from 'kepler.gl/components';
 
 const IconButton = styled(Button)`
   padding: 0;
@@ -40,7 +40,8 @@ const KEPLER_UI = {
   Icons,
   Input,
   ItemSelector,
-  Slider
+  Slider,
+  LoadingSpinner
 };
 
 // Redux stores/actions

--- a/modules/core/src/capture/video-capture.js
+++ b/modules/core/src/capture/video-capture.js
@@ -161,19 +161,19 @@ export class VideoCapture {
       this.recording = false;
       this.capturing = false; // Added to fix an intermittent bug
       this.encoderSettings = null;
-      this.save();
-
-      if (callback) {
-        // eslint-disable-next-line callback-return
-        callback();
-      }
+      this.save().then(() => {
+        if (callback) {
+          // eslint-disable-next-line callback-return
+          callback();
+        }
+      });
     }
   }
 
   /**
    * @param {{ (blob: Blob): boolean }} [callback]
    */
-  save(callback) {
+  async save(callback) {
     console.timeEnd('render');
     if (!callback) {
       /**
@@ -188,7 +188,7 @@ export class VideoCapture {
       };
     }
     console.time('save');
-    this.encoder.save().then(callback);
+    await this.encoder.save().then(callback);
   }
 
   /**

--- a/modules/react/src/components/export-video/export-video-panel-container.js
+++ b/modules/react/src/components/export-video/export-video-panel-container.js
@@ -144,13 +144,9 @@ export class ExportVideoPanelContainer extends Component {
   }
 
   getDeckScene(animationLoop) {
-    // PSEUDO BRAINSTORM
-    // only runs once and permanently sets things like canvas resolution + duration
     const {durationMs} = this.state;
     const {width, height} = this.getCanvasSize();
 
-    // TODO this scales canvas resolution but is only set once. Figure out how to update
-    // TODO this needs to update durationMs
     return new DeckScene({
       animationLoop,
       lengthMs: durationMs,
@@ -224,7 +220,6 @@ export class ExportVideoPanelContainer extends Component {
   setDuration(durationMs) {
     const {adapter} = this.state;
     adapter.scene.setDuration(durationMs);
-    // function passed down to Slider class in ExportVideoPanelSettings
     this.setStateAndNotify({durationMs});
   }
 

--- a/modules/react/src/components/export-video/export-video-panel-container.js
+++ b/modules/react/src/components/export-video/export-video-panel-container.js
@@ -78,9 +78,10 @@ export class ExportVideoPanelContainer extends Component {
       cameraPreset: 'Orbit (90º)',
       fileName: '',
       resolution: '1280x720',
-      durationMs: 1000, // TODO change to 5000 later. 1000 for dev testing
+      durationMs: 1000,
       viewState: mapState,
       adapter: new DeckAdapter(this.getDeckScene, glContext),
+      rendering: false, // Will set a spinner overlay if true
       ...(initialState || {})
     };
   }
@@ -211,7 +212,11 @@ export class ExportVideoPanelContainer extends Component {
     const {adapter} = this.state;
     const Encoder = this.getEncoder();
     const encoderSettings = this.getEncoderSettings();
-    const onStop = () => {};
+
+    this.setState({rendering: true}); // Enables overlay to give user feedback on rendering
+    const onStop = () => {
+      this.setState({rendering: false});
+    }; // Disables overlay once export is done rendering
 
     adapter.render(this.getCameraKeyframes, Encoder, encoderSettings, onStop);
   }
@@ -232,7 +237,8 @@ export class ExportVideoPanelContainer extends Component {
       cameraPreset,
       fileName,
       resolution,
-      viewState
+      viewState,
+      rendering
     } = this.state;
 
     const settingsData = {mediaType, cameraPreset, fileName, resolution};
@@ -265,6 +271,7 @@ export class ExportVideoPanelContainer extends Component {
         frameRate={encoderSettings.framerate}
         resolution={[width, height]}
         mediaType={mediaType}
+        rendering={rendering}
       />
     );
   }

--- a/modules/react/src/components/export-video/export-video-panel-container.js
+++ b/modules/react/src/components/export-video/export-video-panel-container.js
@@ -209,10 +209,10 @@ export class ExportVideoPanelContainer extends Component {
     const Encoder = this.getEncoder();
     const encoderSettings = this.getEncoderSettings();
 
-    this.setState({rendering: true}); // Enables overlay to give user feedback on rendering
+    this.setState({rendering: true}); // Enables overlay after user clicks "Render"
     const onStop = () => {
       this.setState({rendering: false});
-    }; // Disables overlay once export is done rendering
+    }; // Disables overlay once export is done saving (generates file to download)
 
     adapter.render(this.getCameraKeyframes, Encoder, encoderSettings, onStop);
   }

--- a/modules/react/src/components/export-video/export-video-panel-footer.js
+++ b/modules/react/src/components/export-video/export-video-panel-footer.js
@@ -40,7 +40,12 @@ const ButtonGroup = styled.div`
   display: flex;
 `;
 
-const ExportVideoPanelFooter = ({handleClose, handlePreviewVideo, handleRenderVideo}) => (
+const ExportVideoPanelFooter = ({
+  handleClose,
+  handlePreviewVideo,
+  handleRenderVideo,
+  rendering
+}) => (
   <WithKeplerUI>
     {({Button}) => (
       <PanelFooterInner className="export-video-panel__footer">
@@ -50,6 +55,7 @@ const ExportVideoPanelFooter = ({handleClose, handlePreviewVideo, handleRenderVi
           secondary
           className={'export-video-button'}
           onClick={handlePreviewVideo}
+          disabled={rendering}
         >
           Preview
         </Button>
@@ -68,6 +74,7 @@ const ExportVideoPanelFooter = ({handleClose, handlePreviewVideo, handleRenderVi
             height={DEFAULT_BUTTON_HEIGHT}
             className={'export-video-button'}
             onClick={handleRenderVideo}
+            disabled={rendering}
           >
             Render
           </Button>

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -194,8 +194,13 @@ export class ExportVideoPanelPreview extends Component {
     };
 
     const loaderStyle = {
-      display: this.props.rendering === false ? 'none' : 'block',
-      position: 'absolute'
+      display: this.props.rendering === false ? 'none' : 'flex',
+      position: 'absolute',
+      background: 'rgba(0, 0, 0, 0.5)',
+      width: `${this.props.exportVideoWidth}px`,
+      height: `${this._getContainerHeight()}px`,
+      alignItems: 'center',
+      justifyContent: 'center'
     };
 
     return (

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -234,7 +234,10 @@ export class ExportVideoPanelPreview extends Component {
                 className="rendering-percent"
                 style={{color: 'white', position: 'absolute', top: '175px'}}
               >
-                {((this.props.adapter.videoCapture.timeMs / 1000) * 100).toFixed(0)} %
+                {((this.props.adapter.videoCapture.timeMs / this.props.durationMs) * 100).toFixed(
+                  0
+                )}{' '}
+                %
               </div>
             </div>
           </>

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -234,9 +234,9 @@ export class ExportVideoPanelPreview extends Component {
                 className="rendering-percent"
                 style={{color: 'white', position: 'absolute', top: '175px'}}
               >
-                {((this.props.adapter.videoCapture.timeMs / this.props.durationMs) * 100).toFixed(
-                  0
-                )}{' '}
+                {Math.floor(
+                  (this.props.adapter.videoCapture.timeMs / this.props.durationMs) * 100
+                ).toFixed(0)}{' '}
                 %
               </div>
             </div>

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -229,6 +229,13 @@ export class ExportVideoPanelPreview extends Component {
             </div>
             <div className="loader" style={loaderStyle}>
               <LoadingSpinner />
+              {/* TODO change text styling to match Kepler's */}
+              <div
+                className="rendering-percent"
+                style={{color: 'white', position: 'absolute', top: '175px'}}
+              >
+                {((this.props.adapter.videoCapture.timeMs / 1000) * 100).toFixed(0)} %
+              </div>
             </div>
           </>
         )}

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -146,16 +146,21 @@ export class ExportVideoPanelPreview extends Component {
     return exportVideoWidth / aspectRatio;
   }
 
+  createLayers() {
+    // returns an arr of DeckGL layer objects
+    const layerOrder = this.props.mapData.visState.layerOrder;
+    return layerOrder
+      .slice()
+      .reverse()
+      .reduce(this._renderLayer, []); // Slicing & reversing to create same layer order as Kepler
+  }
+
   _onMapLoad() {
     // Adds mapbox layer to modal
     const map = this.mapRef.current.getMap();
     const deck = this.deckRef.current.deck;
 
-    const layerOrder = this.props.mapData.visState.layerOrder;
-    const keplerLayers = layerOrder
-      .slice()
-      .reverse()
-      .reduce(this._renderLayer, []);
+    const keplerLayers = this.createLayers();
 
     map.addLayer(new MapboxLayer({id: 'my-deck', deck}));
 
@@ -172,16 +177,6 @@ export class ExportVideoPanelPreview extends Component {
   }
 
   render() {
-    const layerOrder = this.props.mapData.visState.layerOrder;
-    let deckGlLayers = [];
-
-    if (layerOrder && layerOrder.length) {
-      deckGlLayers = layerOrder
-        .slice()
-        .reverse()
-        .reduce(this._renderLayer, []);
-    }
-
     const deckStyle = {
       width: '100%',
       height: '100%'
@@ -212,7 +207,7 @@ export class ExportVideoPanelPreview extends Component {
                 ref={this.deckRef}
                 viewState={this.props.viewState}
                 id="hubblegl-overlay"
-                layers={deckGlLayers}
+                layers={this.createLayers()}
                 style={deckStyle}
                 controller={true}
                 glOptions={{stencil: true}}

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -184,8 +184,7 @@ export class ExportVideoPanelPreview extends Component {
 
     const deckStyle = {
       width: '100%',
-      height: '100%',
-      display: this.props.rendering === true ? 'none' : ''
+      height: '100%'
     };
 
     const containerStyle = {
@@ -195,50 +194,43 @@ export class ExportVideoPanelPreview extends Component {
     };
 
     const loaderStyle = {
-      // Temporary spinner
-      border: '16px solid #f3f3f3' /* Light grey */,
-      borderTop: '16px solid #3498db' /* Blue */,
-      borderRadius: '50%',
-      margin: 'auto',
-      width: '120px',
-      height: '120px',
-      animation: 'spin 2s linear infinite',
-      display: this.props.rendering === false ? 'none' : ''
+      display: this.props.rendering === false ? 'none' : 'block',
+      position: 'absolute'
     };
-
-    // NOTE Separate loading spinner used temporarily. Couldn't figure out how to modify Kepler's
-    // Also, spinner displays hidden as opposed to overlay due to limitation on Mapbox submodule https://deck.gl/docs/api-reference/mapbox/overview#limitations
 
     return (
       <WithKeplerUI>
         {({LoadingSpinner}) => (
-          // <LoadingSpinner className="TEST123" style={{margin: 'auto'}}>  TODO margin auto works but doesn't inherit? */}
-          <div id="deck-canvas" style={containerStyle}>
-            <div className="loader" style={loaderStyle} />
-            <DeckGL
-              ref={this.deckRef}
-              viewState={this.props.viewState}
-              id="hubblegl-overlay"
-              layers={deckGlLayers}
-              style={deckStyle}
-              controller={true}
-              glOptions={{stencil: true}}
-              onWebGLInitialized={gl => this.setState({glContext: gl})}
-              onViewStateChange={this.props.setViewState}
-              // onClick={visStateActions.onLayerClick}
-              {...this.props.adapter.getProps(this.deckRef, () => {})}
-            >
-              {this.state.glContext && (
-                <StaticMap
-                  ref={this.mapRef}
-                  mapStyle={this.state.mapStyle}
-                  preventStyleDiffing={true}
-                  gl={this.state.glContext}
-                  onLoad={this._onMapLoad}
-                />
-              )}
-            </DeckGL>
-          </div>
+          <>
+            <div id="deck-canvas" style={containerStyle}>
+              <DeckGL
+                ref={this.deckRef}
+                viewState={this.props.viewState}
+                id="hubblegl-overlay"
+                layers={deckGlLayers}
+                style={deckStyle}
+                controller={true}
+                glOptions={{stencil: true}}
+                onWebGLInitialized={gl => this.setState({glContext: gl})}
+                onViewStateChange={this.props.setViewState}
+                // onClick={visStateActions.onLayerClick}
+                {...this.props.adapter.getProps(this.deckRef, () => {})}
+              >
+                {this.state.glContext && (
+                  <StaticMap
+                    ref={this.mapRef}
+                    mapStyle={this.state.mapStyle}
+                    preventStyleDiffing={true}
+                    gl={this.state.glContext}
+                    onLoad={this._onMapLoad}
+                  />
+                )}
+              </DeckGL>
+            </div>
+            <div className="loader" style={loaderStyle}>
+              <LoadingSpinner />
+            </div>
+          </>
         )}
       </WithKeplerUI>
     );

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -152,15 +152,16 @@ export class ExportVideoPanelPreview extends Component {
     const deck = this.deckRef.current.deck;
 
     const layerOrder = this.props.mapData.visState.layerOrder;
-    const keplerLayers = layerOrder.reduce(this._renderLayer, []);
+    const keplerLayers = layerOrder
+      .slice()
+      .reverse()
+      .reduce(this._renderLayer, []);
 
     map.addLayer(new MapboxLayer({id: 'my-deck', deck}));
 
     for (let i = 0; i < keplerLayers.length; i++) {
-      // Adds DeckGL layers to Mapbox so it can be the bottom layer. Removing this clips DeckGL layers
-      // console.log('layer', keplerLayers[i]);
+      // Adds DeckGL layers to Mapbox so Mapbox can be the bottom layer. Removing this clips DeckGL layers
       map.addLayer(new MapboxLayer({id: keplerLayers[i].id, deck}));
-      // deck.setProps(keplerLayers[i].props)
     }
 
     map.on('render', () =>
@@ -171,38 +172,20 @@ export class ExportVideoPanelPreview extends Component {
   }
 
   render() {
-    // const mapStyle = this.mapData.mapStyle;
-    // const mapState = this.props.mapData.mapState;
-    // const layers = this.mapData.visState.layers;
-    // const layerData = this.mapData.visState.layerData;
     const layerOrder = this.props.mapData.visState.layerOrder;
-    // const animationConfig = this.mapData.visState.animationConfig;
-
-    // Map data
-    // const mapboxApiAccessToken = this.props.mapData.mapStyle.mapboxApiAccessToken;
-    // const mapboxApiUrl = this.props.mapData.mapStyle.mapboxApiUrl;
-
-    // define trip and geojson layers
     let deckGlLayers = [];
 
-    // TODO refactor this. Layers are reverse, filtered, etc. only to be redefined later
-    // wait until data is ready before render data layers
     if (layerOrder && layerOrder.length) {
-      // last layer render first
       deckGlLayers = layerOrder
         .slice()
         .reverse()
-        // .filter(
-        //   idx => layers[idx].overlayType === OVERLAY_TYPE.deckgl && layers[idx].id
-        // )
         .reduce(this._renderLayer, []);
     }
 
     const deckStyle = {
       width: '100%',
       height: '100%',
-      // display: none if rendering == true
-      display: this.props.rendering === true ? 'none' : 'initial'
+      display: this.props.rendering === true ? 'none' : ''
     };
 
     const containerStyle = {
@@ -212,49 +195,49 @@ export class ExportVideoPanelPreview extends Component {
     };
 
     const loaderStyle = {
+      // Temporary spinner
       border: '16px solid #f3f3f3' /* Light grey */,
       borderTop: '16px solid #3498db' /* Blue */,
       borderRadius: '50%',
       margin: 'auto',
       width: '120px',
       height: '120px',
-      animation: 'spin 2s linear infinite'
-      // display: (this.props.rendering === false) ? "none" : "initial"
-      // display: none if rendering == false
+      animation: 'spin 2s linear infinite',
+      display: this.props.rendering === false ? 'none' : ''
     };
+
+    // NOTE Separate loading spinner used temporarily. Couldn't figure out how to modify Kepler's
+    // Also, spinner displays hidden as opposed to overlay due to limitation on Mapbox submodule https://deck.gl/docs/api-reference/mapbox/overview#limitations
 
     return (
       <WithKeplerUI>
         {({LoadingSpinner}) => (
-          <div>
-            {/* // <LoadingSpinner className="TEST123" style={{margin: 'auto'}}>  TODO margin auto works but doesn't inherit? */}
-            <div id="deck-canvas" style={containerStyle}>
-              <div className="loader" style={loaderStyle} />
-              <DeckGL
-                ref={this.deckRef}
-                viewState={this.props.viewState}
-                id="hubblegl-overlay"
-                layers={deckGlLayers}
-                style={deckStyle}
-                controller={true}
-                glOptions={{stencil: true}}
-                onWebGLInitialized={gl => this.setState({glContext: gl})}
-                onViewStateChange={this.props.setViewState}
-                // onClick={visStateActions.onLayerClick}
-                {...this.props.adapter.getProps(this.deckRef, () => {})}
-              >
-                {this.state.glContext && (
-                  <StaticMap
-                    ref={this.mapRef}
-                    // reuseMaps // Part of default example but causes modal to lose Mapbox tile layer?
-                    mapStyle={this.state.mapStyle}
-                    preventStyleDiffing={true}
-                    gl={this.state.glContext}
-                    onLoad={this._onMapLoad}
-                  />
-                )}
-              </DeckGL>
-            </div>
+          // <LoadingSpinner className="TEST123" style={{margin: 'auto'}}>  TODO margin auto works but doesn't inherit? */}
+          <div id="deck-canvas" style={containerStyle}>
+            <div className="loader" style={loaderStyle} />
+            <DeckGL
+              ref={this.deckRef}
+              viewState={this.props.viewState}
+              id="hubblegl-overlay"
+              layers={deckGlLayers}
+              style={deckStyle}
+              controller={true}
+              glOptions={{stencil: true}}
+              onWebGLInitialized={gl => this.setState({glContext: gl})}
+              onViewStateChange={this.props.setViewState}
+              // onClick={visStateActions.onLayerClick}
+              {...this.props.adapter.getProps(this.deckRef, () => {})}
+            >
+              {this.state.glContext && (
+                <StaticMap
+                  ref={this.mapRef}
+                  mapStyle={this.state.mapStyle}
+                  preventStyleDiffing={true}
+                  gl={this.state.glContext}
+                  onLoad={this._onMapLoad}
+                />
+              )}
+            </DeckGL>
           </div>
         )}
       </WithKeplerUI>

--- a/modules/react/src/components/export-video/export-video-panel-settings.js
+++ b/modules/react/src/components/export-video/export-video-panel-settings.js
@@ -148,7 +148,7 @@ const ExportVideoPanelSettings = ({
           </StyledValueCell>
           <StyledLabelCell>File Size</StyledLabelCell>
           <StyledValueCell>
-            {estimateFileSize(frameRate, resolution, durationMs, mediaType)}
+            ~ {estimateFileSize(frameRate, resolution, durationMs, mediaType)}
           </StyledValueCell>
         </InputGrid>
         <StyledSection>Video Effects</StyledSection>

--- a/modules/react/src/components/export-video/export-video-panel-settings.js
+++ b/modules/react/src/components/export-video/export-video-panel-settings.js
@@ -123,7 +123,7 @@ const ExportVideoPanelSettings = ({
             onChange={setResolution}
           />
           <StyledLabelCell>Duration</StyledLabelCell>
-          <StyledValueCell>
+          <StyledValueCell style={{paddingLeft: '0px', paddingRight: '0px'}}>
             <SliderWrapper
               style={{width: '100%', marginLeft: '0px'}}
               className="modal-duration__slider"

--- a/modules/react/src/components/export-video/export-video-panel.js
+++ b/modules/react/src/components/export-video/export-video-panel.js
@@ -82,7 +82,8 @@ const PanelBody = ({
   resolution,
   mediaType,
   viewState,
-  setDuration
+  setDuration,
+  rendering
 }) => (
   <PanelBodyInner className="export-video-panel__body" exportVideoWidth={exportVideoWidth}>
     <ExportVideoPanelPreview
@@ -92,6 +93,7 @@ const PanelBody = ({
       exportVideoWidth={exportVideoWidth}
       resolution={resolution}
       viewState={viewState}
+      rendering={rendering}
     />
     <ExportVideoPanelSettings
       setMediaType={setMediaType}
@@ -137,7 +139,8 @@ const ExportVideoPanel = ({
   resolution,
   mediaType,
   viewState,
-  setDuration
+  setDuration,
+  rendering
 }) => {
   return (
     <Panel exportVideoWidth={exportVideoWidth} className="export-video-panel">
@@ -163,6 +166,7 @@ const ExportVideoPanel = ({
         mediaType={mediaType}
         viewState={viewState}
         setDuration={setDuration}
+        rendering={rendering}
       />
       <ExportVideoPanelFooter
         handleClose={handleClose}

--- a/modules/react/src/components/export-video/export-video-panel.js
+++ b/modules/react/src/components/export-video/export-video-panel.js
@@ -94,6 +94,7 @@ const PanelBody = ({
       resolution={resolution}
       viewState={viewState}
       rendering={rendering}
+      durationMs={durationMs}
     />
     <ExportVideoPanelSettings
       setMediaType={setMediaType}

--- a/modules/react/src/components/export-video/export-video-panel.js
+++ b/modules/react/src/components/export-video/export-video-panel.js
@@ -172,6 +172,7 @@ const ExportVideoPanel = ({
         handleClose={handleClose}
         handlePreviewVideo={handlePreviewVideo}
         handleRenderVideo={handleRenderVideo}
+        rendering={rendering}
       />
     </Panel>
   );

--- a/modules/react/src/components/export-video/utils.js
+++ b/modules/react/src/components/export-video/utils.js
@@ -90,7 +90,7 @@ export function msConversion(durationMs) {
   minutes = minutes < 10 ? `0${minutes}` : minutes;
   seconds = seconds < 10 ? `0${seconds}` : seconds;
 
-  return `${minutes}:${seconds}.${milliseconds}`;
+  return `${minutes}:${seconds}.${milliseconds.toString()[0]}`;
 }
 
 /**

--- a/modules/react/src/components/export-video/utils.js
+++ b/modules/react/src/components/export-video/utils.js
@@ -76,9 +76,9 @@ export function parseSetCameraType(strCameraType, viewState) {
 }
 
 /**
- * Used to convert durationMs (inherited from ExportVideoPanelContainer) to hh:mm:ss
+ * Used to convert durationMs (inherited from ExportVideoPanelContainer) to hh:mm:ss.ms
  * @param {number} durationMs duration of animation in milliseconds
- * @returns {string} time in format hh:mm:ss
+ * @returns {string} time in format hh:mm:ss.ms
  */
 export function msConversion(durationMs) {
   const milliseconds = parseInt(durationMs % 1000, 10);


### PR DESCRIPTION
## Changelog

- Pressing "Render" now gives user feedback by showing Kepler's spinner. Note that this does not happen when "Preview" is pressed. Options are disabled while rendering.
- DeckGL layers no longer clips
- Time conversion now only shows 1 digit
- Size of duration now equal with the other sections
- Black 50% opacity overlay
- Spinner & total time match up. Save function in video-capture.js made asynchronous
- Percentage now below spinner showing % done

## Known Issues
- Styling does not match Kepler. Or % won't be visible on all backgrounds