### PR TITLE
Updated onStop documentation

### DIFF
--- a/modules/core/docs/deck-adapter.md
+++ b/modules/core/docs/deck-adapter.md
@@ -59,7 +59,7 @@ See [FrameEncoder](/modules/core/docs/encoder/frame-encoder#constructor-1) for i
 
 * **`onStop` (`() => void`, Optional) - Default: `undefined`.**
 
-This function is called after the last frame is rendered. It does not get called when a render is interrupted with `stop()`.
+This function is called after the last frame is rendered and a file is created for download. It does not get called when a render is interrupted with `stop()`.
 
 ##### `stop(callback)`
 


### PR DESCRIPTION
Callbacks were changed in #58 to happen right after saving.

https://github.com/uber/hubble.gl/pull/58/files#diff-f2b2ddef3003d116a87f5e29beee8a5ab978e06627958732dd8972fa9d3d9d0dR164