### PR TITLE
Add jpegQuality to GIF and default to 1.0

### DIFF
--- a/modules/core/src/encoders/video/gif-encoder.js
+++ b/modules/core/src/encoders/video/gif-encoder.js
@@ -18,6 +18,7 @@ export default class GifEncoder extends FrameEncoder {
     this.options.height = this.options.height || 480;
     this.options.numWorkers = this.options.numWorkers || 4;
     this.options.sampleInterval = this.options.sampleInterval || 10;
+    this.options.jpegQuality = this.options.jpegQuality || 1.0;
 
     // this.source = settings.source
     this.source = 'images';
@@ -38,7 +39,7 @@ export default class GifEncoder extends FrameEncoder {
   /** @param {HTMLCanvasElement} canvas */
   async add(canvas) {
     if (this.source === 'images') {
-      const dataUrl = canvas.toDataURL('image/jpeg', 0.8);
+      const dataUrl = canvas.toDataURL('image/jpeg', this.options.jpegQuality);
       await this.gifBuilder.add(dataUrl);
     }
   }

--- a/modules/core/src/types.d.ts
+++ b/modules/core/src/types.d.ts
@@ -41,6 +41,7 @@ interface EncoderSettings {
     sampleInterval: number,
     width: number,
     height: number
+    jpegQuality: number
   },
 }
 


### PR DESCRIPTION
Changing JPEG quality from 80% to 100% for GIF input frames decreases GIF size in testing and increases quality. Leave the compression to the GIF library.

Resolution | 80% | 100%
------------ | ------------ | -------------
720p | 15.8MB | 13.7MB
1080p | 34.6MB | 21.2MB
