### PR TITLE
Modal refinements

### DIFF
--- a/examples/kepler-integration/src/app.js
+++ b/examples/kepler-integration/src/app.js
@@ -38,6 +38,7 @@ const KeplerGl = require('kepler.gl/components').injectComponents([
   replaceLoadDataModal(),
   replaceMapControl(),
   replacePanelHeader()
+  // TODO add 4th custom factory for Hubble export modal. Replace SaveExportDropdownFactory
 ]);
 
 // Sample data

--- a/examples/kepler-integration/src/components/export-video.js
+++ b/examples/kepler-integration/src/components/export-video.js
@@ -32,8 +32,12 @@ import {
   ItemSelector,
   Slider,
   LoadingSpinner,
-  ModalTabsFactory
+  ModalTabsFactory,
+  Play
 } from 'kepler.gl/components';
+
+// import Play from 'kepler.gl/components';
+// import {Reset, Play, Pause, Rocket, AnchorWindow, FreeWindow} from 'components/common/icons';
 
 const IconButton = styled(Button)`
   padding: 0;
@@ -50,7 +54,8 @@ const KEPLER_UI = {
   ItemSelector,
   Slider,
   LoadingSpinner,
-  ModalTabsFactory
+  ModalTabsFactory,
+  Play
 };
 
 // Redux stores/actions

--- a/examples/kepler-integration/src/components/export-video.js
+++ b/examples/kepler-integration/src/components/export-video.js
@@ -36,9 +36,6 @@ import {
   Play
 } from 'kepler.gl/components';
 
-// import Play from 'kepler.gl/components';
-// import {Reset, Play, Pause, Rocket, AnchorWindow, FreeWindow} from 'components/common/icons';
-
 const IconButton = styled(Button)`
   padding: 0;
   svg {

--- a/modules/react/src/components/export-video/constants.js
+++ b/modules/react/src/components/export-video/constants.js
@@ -95,5 +95,19 @@ export function getResolutionSetting(value) {
 
 export const deckStyle = {
   width: '100%',
-  height: '100%'
+  height: '100%',
+  position: 'relative'
+};
+
+export const timelineControlStyle = {
+  position: 'relative',
+  display: 'flex',
+  justifyContent: 'center'
+};
+
+export const timelinePlayButtonStyle = {
+  cursor: 'pointer',
+  height: '50px',
+  width: '50px',
+  fill: '#FFF'
 };

--- a/modules/react/src/components/export-video/constants.js
+++ b/modules/react/src/components/export-video/constants.js
@@ -51,39 +51,45 @@ export const FORMATS = [
 export const RESOLUTIONS = [
   {
     value: '960x540',
-    label: 'Good 16:9 (540p)',
+    label: 'Good (540p)',
     width: 960,
-    height: 540
+    height: 540,
+    aspectRatio: '16:9'
   },
   {
     value: '1280x720',
-    label: 'High 16:9 (720p)',
+    label: 'High (720p)',
     width: 1280,
-    height: 720
+    height: 720,
+    aspectRatio: '16:9'
   },
   {
     value: '1920x1080',
-    label: 'Highest 16:9 (1080p)',
+    label: 'Highest (1080p)',
     width: 1920,
-    height: 1080
+    height: 1080,
+    aspectRatio: '16:9'
   },
   {
     value: '640x480',
-    label: 'Good 4:3 (480p)',
+    label: 'Good (480p)',
     width: 640,
-    height: 480
+    height: 480,
+    aspectRatio: '4:3'
   },
   {
     value: '1280x960',
-    label: 'High 4:3 (960p)',
+    label: 'High (960p)',
     width: 1280,
-    height: 960
+    height: 960,
+    aspectRatio: '4:3'
   },
   {
     value: '1920x1440',
-    label: 'Highest 4:3 (1440p)',
+    label: 'Highest (1440p)',
     width: 1920,
-    height: 1440
+    height: 1440,
+    aspectRatio: '4:3'
   }
 ];
 

--- a/modules/react/src/components/export-video/export-video-panel-footer.js
+++ b/modules/react/src/components/export-video/export-video-panel-footer.js
@@ -30,16 +30,6 @@ const ExportVideoPanelFooter = ({handlePreviewVideo, handleRenderVideo, renderin
   <WithKeplerUI>
     {({Button}) => (
       <PanelFooterInner className="export-video-panel__footer">
-        <Button
-          width={DEFAULT_BUTTON_WIDTH}
-          height={DEFAULT_BUTTON_HEIGHT}
-          secondary
-          className={'export-video-button'}
-          onClick={handlePreviewVideo}
-          disabled={rendering}
-        >
-          Preview
-        </Button>
         <ButtonGroup>
           <Button
             width={DEFAULT_BUTTON_WIDTH}

--- a/modules/react/src/components/export-video/export-video-panel-footer.js
+++ b/modules/react/src/components/export-video/export-video-panel-footer.js
@@ -21,26 +21,15 @@
 import React from 'react';
 import {withTheme} from 'styled-components';
 
-import {DEFAULT_BUTTON_HEIGHT, DEFAULT_BUTTON_WIDTH} from './constants';
 import {WithKeplerUI} from '../inject-kepler';
 
-import {PanelFooterInner, ButtonGroup} from './styled-components';
+import {PanelFooterInner} from './styled-components';
 
-const ExportVideoPanelFooter = ({handlePreviewVideo, handleRenderVideo, rendering}) => (
+const ExportVideoPanelFooter = () => (
   <WithKeplerUI>
-    {({Button}) => (
+    {({}) => (
       <PanelFooterInner className="export-video-panel__footer">
-        <ButtonGroup>
-          <Button
-            width={DEFAULT_BUTTON_WIDTH}
-            height={DEFAULT_BUTTON_HEIGHT}
-            className={'export-video-button'}
-            onClick={handleRenderVideo}
-            disabled={rendering}
-          >
-            Render
-          </Button>
-        </ButtonGroup>
+        {/* NOTE RW - Unused for now but didn't delete in case we needed in the future */}
       </PanelFooterInner>
     )}
   </WithKeplerUI>

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -197,8 +197,6 @@ export class ExportVideoPanelPreview extends Component {
     };
 
     return (
-      // TODO import Play class, assign it to handlePreviewVideo
-      // https://github.com/keplergl/kepler.gl/blob/14c35fc048a745faab0c6770cab7a4625ccedda3/src/components/common/icons/play.js
       <WithKeplerUI>
         {({Icons}) => (
           <>

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -23,8 +23,9 @@ import DeckGL from '@deck.gl/react';
 import {StaticMap} from 'react-map-gl';
 import {MapboxLayer} from '@deck.gl/mapbox';
 
-import {deckStyle} from './constants';
+import {deckStyle, timelineControlStyle, timelinePlayButtonStyle} from './constants';
 import {RenderingSpinner} from './rendering-spinner';
+import {WithKeplerUI} from '../inject-kepler';
 
 export class ExportVideoPanelPreview extends Component {
   constructor(props) {
@@ -178,7 +179,15 @@ export class ExportVideoPanelPreview extends Component {
   }
 
   render() {
-    const {exportVideoWidth, rendering, viewState, setViewState, adapter, durationMs} = this.props;
+    const {
+      exportVideoWidth,
+      rendering,
+      viewState,
+      setViewState,
+      adapter,
+      durationMs,
+      handlePreviewVideo
+    } = this.props;
     const {glContext, mapStyle} = this.state;
 
     const containerStyle = {
@@ -188,42 +197,51 @@ export class ExportVideoPanelPreview extends Component {
     };
 
     return (
-      <>
-        <div id="deck-canvas" style={containerStyle}>
-          <DeckGL
-            ref={this.deckRef}
-            viewState={viewState}
-            id="hubblegl-overlay"
-            layers={this.createLayers()}
-            style={deckStyle}
-            controller={true}
-            glOptions={{stencil: true}}
-            onWebGLInitialized={gl => this.setState({glContext: gl})}
-            onViewStateChange={setViewState}
-            // onClick={visStateActions.onLayerClick}
-            {...adapter.getProps({deckRef: this.deckRef, setReady: () => {}})}
-          >
-            {glContext && (
-              <StaticMap
-                ref={this.mapRef}
-                mapStyle={mapStyle}
-                preventStyleDiffing={true}
-                gl={glContext}
-                onLoad={this._onMapLoad}
+      // TODO import Play class, assign it to handlePreviewVideo
+      // https://github.com/keplergl/kepler.gl/blob/14c35fc048a745faab0c6770cab7a4625ccedda3/src/components/common/icons/play.js
+      <WithKeplerUI>
+        {({Icons}) => (
+          <>
+            <div id="deck-canvas" style={containerStyle}>
+              <DeckGL
+                ref={this.deckRef}
+                viewState={viewState}
+                id="hubblegl-overlay"
+                layers={this.createLayers()}
+                style={deckStyle}
+                controller={true}
+                glOptions={{stencil: true}}
+                onWebGLInitialized={gl => this.setState({glContext: gl})}
+                onViewStateChange={setViewState}
+                // onClick={visStateActions.onLayerClick}
+                {...adapter.getProps({deckRef: this.deckRef, setReady: () => {}})}
+              >
+                {glContext && (
+                  <StaticMap
+                    ref={this.mapRef}
+                    mapStyle={mapStyle}
+                    preventStyleDiffing={true}
+                    gl={glContext}
+                    onLoad={this._onMapLoad}
+                  />
+                )}
+              </DeckGL>
+              <div id="timeline-controls" style={timelineControlStyle}>
+                <Icons.Play style={timelinePlayButtonStyle} onClick={handlePreviewVideo} />
+              </div>
+            </div>
+            {rendering && (
+              <RenderingSpinner
+                rendering={rendering}
+                width={exportVideoWidth}
+                height={this._getContainerHeight()}
+                adapter={adapter}
+                durationMs={durationMs}
               />
             )}
-          </DeckGL>
-        </div>
-        {rendering && (
-          <RenderingSpinner
-            rendering={rendering}
-            width={exportVideoWidth}
-            height={this._getContainerHeight()}
-            adapter={adapter}
-            durationMs={durationMs}
-          />
+          </>
         )}
-      </>
+      </WithKeplerUI>
     );
   }
 }

--- a/modules/react/src/components/export-video/export-video-panel-settings.js
+++ b/modules/react/src/components/export-video/export-video-panel-settings.js
@@ -49,14 +49,14 @@ function ExportVideoPanelSettings({
     // label: What the text of the tab will be
     // elementType: The component to render
     {
-      id: 'export-modal-tab-edit',
-      label: 'exportVideoModal.edit',
-      elementType: EditTab
-    },
-    {
       id: 'export-modal-tab-export',
       label: 'exportVideoModal.export',
       elementType: ExportTab
+    },
+    {
+      id: 'export-modal-tab-edit',
+      label: 'exportVideoModal.edit',
+      elementType: EditTab
     }
   ];
   const getDefaultMethod = methods => (Array.isArray(methods) ? get(methods, [0]) : null);

--- a/modules/react/src/components/export-video/export-video-panel-settings.js
+++ b/modules/react/src/components/export-video/export-video-panel-settings.js
@@ -41,7 +41,9 @@ function ExportVideoPanelSettings({
   frameRate,
   resolution,
   mediaType,
-  setDuration
+  setDuration,
+  handleRenderVideo,
+  rendering
 }) {
   const loadingMethods = [
     // Each entry creates new tabs with ModalTabsFactory
@@ -89,6 +91,8 @@ function ExportVideoPanelSettings({
                 resolution={resolution}
                 mediaType={mediaType}
                 setCameraPreset={setCameraPreset}
+                handleRenderVideo={handleRenderVideo}
+                rendering={rendering}
               />
             )}
           </div>

--- a/modules/react/src/components/export-video/export-video-panel.js
+++ b/modules/react/src/components/export-video/export-video-panel.js
@@ -70,7 +70,8 @@ const PanelBody = ({
   mediaType,
   viewState,
   setDuration,
-  rendering
+  rendering,
+  handlePreviewVideo
 }) => (
   <PanelBodyInner className="export-video-panel__body" exportVideoWidth={exportVideoWidth}>
     <ExportVideoPanelPreview
@@ -82,6 +83,7 @@ const PanelBody = ({
       viewState={viewState}
       rendering={rendering}
       durationMs={durationMs}
+      handlePreviewVideo={handlePreviewVideo}
     />
     <ExportVideoPanelSettings
       setMediaType={setMediaType}
@@ -120,7 +122,6 @@ const ExportVideoPanel = ({
   setResolution,
   // Hubble Props
   adapter,
-  handlePreviewVideo,
   handleRenderVideo,
   durationMs,
   frameRate,
@@ -128,7 +129,8 @@ const ExportVideoPanel = ({
   mediaType,
   viewState,
   setDuration,
-  rendering
+  rendering,
+  handlePreviewVideo
 }) => {
   return (
     <Panel exportVideoWidth={exportVideoWidth} className="export-video-panel">
@@ -155,10 +157,10 @@ const ExportVideoPanel = ({
         viewState={viewState}
         setDuration={setDuration}
         rendering={rendering}
+        handlePreviewVideo={handlePreviewVideo}
       />
       <ExportVideoPanelFooter
         handleClose={handleClose}
-        handlePreviewVideo={handlePreviewVideo}
         handleRenderVideo={handleRenderVideo}
         rendering={rendering}
       />

--- a/modules/react/src/components/export-video/export-video-panel.js
+++ b/modules/react/src/components/export-video/export-video-panel.js
@@ -71,7 +71,8 @@ const PanelBody = ({
   viewState,
   setDuration,
   rendering,
-  handlePreviewVideo
+  handlePreviewVideo,
+  handleRenderVideo
 }) => (
   <PanelBodyInner className="export-video-panel__body" exportVideoWidth={exportVideoWidth}>
     <ExportVideoPanelPreview
@@ -96,6 +97,8 @@ const PanelBody = ({
       resolution={resolution}
       mediaType={mediaType}
       setDuration={setDuration}
+      handleRenderVideo={handleRenderVideo}
+      rendering={rendering}
     />
     {/* TODO: inject additional keyframing tools here */}
   </PanelBodyInner>
@@ -158,12 +161,9 @@ const ExportVideoPanel = ({
         setDuration={setDuration}
         rendering={rendering}
         handlePreviewVideo={handlePreviewVideo}
-      />
-      <ExportVideoPanelFooter
-        handleClose={handleClose}
         handleRenderVideo={handleRenderVideo}
-        rendering={rendering}
       />
+      <ExportVideoPanelFooter handleClose={handleClose} />
     </Panel>
   );
 };

--- a/modules/react/src/components/export-video/modal-tab-edit.js
+++ b/modules/react/src/components/export-video/modal-tab-edit.js
@@ -10,15 +10,6 @@ function EditTab({durationMs, setDuration, setCameraPreset, settingsData}) {
       {({Slider, ItemSelector}) => (
         <>
           <InputGrid rows={5}>
-            <StyledLabelCell>Ratio</StyledLabelCell>
-            <ItemSelector
-              disabled={true}
-              selectedItems={'16:9'}
-              options={['4:3', '16:9']}
-              multiSelect={false}
-              searchable={false}
-              onChange={() => {}}
-            />
             <StyledLabelCell>Duration</StyledLabelCell>
             <StyledValueCell style={{paddingLeft: '0px', paddingRight: '0px'}}>
               <SliderWrapper

--- a/modules/react/src/components/export-video/modal-tab-export.js
+++ b/modules/react/src/components/export-video/modal-tab-export.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 
 import {estimateFileSize} from './utils';
 import {StyledLabelCell, StyledValueCell, InputGrid} from './styled-components';
@@ -26,6 +26,8 @@ function ExportTab({
   handleRenderVideo,
   rendering
 }) {
+  const [aspRatio, setAspRatio] = useState('16:9');
+
   return (
     <WithKeplerUI>
       {({Input, ItemSelector, Button}) => (
@@ -47,10 +49,20 @@ function ExportTab({
               searchable={false}
               onChange={setMediaType}
             />
-            <StyledLabelCell>Resolution</StyledLabelCell>
+            <StyledLabelCell>Aspect Ratio</StyledLabelCell>
             <ItemSelector
-              selectedItems={getSelectedItems(RESOLUTIONS, settingsData.resolution)}
-              options={RESOLUTIONS}
+              selectedItems={aspRatio}
+              options={['4:3', '16:9']}
+              multiSelect={false}
+              searchable={false}
+              onChange={ratio => {
+                setAspRatio(ratio);
+              }}
+            />
+            <StyledLabelCell>Quality</StyledLabelCell>
+            <ItemSelector
+              selectedItems={getSelectedItems(RESOLUTIONS, settingsData.resolution)} // TODO selected item should change every aspect ratio swap
+              options={RESOLUTIONS.filter(o => o.aspectRatio === aspRatio)}
               getOptionValue={getOptionValue}
               displayOption={displayOption}
               multiSelect={false}

--- a/modules/react/src/components/export-video/modal-tab-export.js
+++ b/modules/react/src/components/export-video/modal-tab-export.js
@@ -57,11 +57,17 @@ function ExportTab({
               searchable={false}
               onChange={ratio => {
                 setAspRatio(ratio);
+                if (aspRatio === '4:3') {
+                  settingsData.resolution = '1280x720';
+                } else {
+                  settingsData.resolution = '1280x960';
+                }
+                setResolution(settingsData.resolution);
               }}
             />
             <StyledLabelCell>Quality</StyledLabelCell>
             <ItemSelector
-              selectedItems={getSelectedItems(RESOLUTIONS, settingsData.resolution)} // TODO selected item should change every aspect ratio swap
+              selectedItems={getSelectedItems(RESOLUTIONS, settingsData.resolution)}
               options={RESOLUTIONS.filter(o => o.aspectRatio === aspRatio)}
               getOptionValue={getOptionValue}
               displayOption={displayOption}

--- a/modules/react/src/components/export-video/modal-tab-export.js
+++ b/modules/react/src/components/export-video/modal-tab-export.js
@@ -2,7 +2,13 @@ import React from 'react';
 
 import {estimateFileSize} from './utils';
 import {StyledLabelCell, StyledValueCell, InputGrid} from './styled-components';
-import {DEFAULT_FILENAME, FORMATS, RESOLUTIONS} from './constants';
+import {
+  DEFAULT_FILENAME,
+  DEFAULT_BUTTON_HEIGHT,
+  DEFAULT_BUTTON_WIDTH,
+  FORMATS,
+  RESOLUTIONS
+} from './constants';
 import {WithKeplerUI} from '../inject-kepler';
 
 function ExportTab({
@@ -16,11 +22,13 @@ function ExportTab({
   durationMs,
   frameRate,
   resolution,
-  mediaType
+  mediaType,
+  handleRenderVideo,
+  rendering
 }) {
   return (
     <WithKeplerUI>
-      {({Input, ItemSelector}) => (
+      {({Input, ItemSelector, Button}) => (
         <>
           <InputGrid rows={5}>
             <StyledLabelCell>File Name</StyledLabelCell>
@@ -53,6 +61,15 @@ function ExportTab({
             <StyledValueCell>
               ~{estimateFileSize(frameRate, resolution, durationMs, mediaType)}
             </StyledValueCell>
+            <Button
+              width={DEFAULT_BUTTON_WIDTH}
+              height={DEFAULT_BUTTON_HEIGHT}
+              className={'export-video-button'}
+              onClick={handleRenderVideo}
+              disabled={rendering}
+            >
+              Render
+            </Button>
           </InputGrid>
         </>
       )}


### PR DESCRIPTION
# Changelog
- Export is now the default tab
- Preview button changed from button to icon below map preview
- Render moved to Export tab
- Aspect ratio added to constants.js
- Aspect ratio option added. Only resolutions of selected aspect ratio will appear. In addition, map preview will change based on aspect ratio selected
- "Resolution" dropdown changed to "Quality"
- Text from "Resolution" simplified by dropping aspect ratios. Ex: "Good 16:9 (720p)" to "Good (720p)"