### PR TITLE
Support animations of visConfig, filters, and mapState

### DIFF
--- a/examples/worldview/src/features/kepler/keplerSlice.js
+++ b/examples/worldview/src/features/kepler/keplerSlice.js
@@ -18,10 +18,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import keplerGlReducer, {combinedUpdaters, uiStateUpdaters} from 'kepler.gl/reducers';
+import keplerGlReducer, {
+  combinedUpdaters,
+  uiStateUpdaters,
+  mapStateUpdaters
+} from 'kepler.gl/reducers';
 import {AUTH_TOKENS} from '../../constants';
 import {EXPORT_MAP_FORMATS} from 'kepler.gl/constants';
 import {loadRemoteKeplerMap} from './loadKeplerMap';
+import {updateViewState} from '../stage/mapSlice';
 
 const {DEFAULT_EXPORT_MAP} = uiStateUpdaters;
 
@@ -52,5 +57,11 @@ export default keplerGlReducer
           config: action.payload.config
         }
       });
+    },
+    [updateViewState]: (state, action) => {
+      return {
+        ...state,
+        mapState: mapStateUpdaters.updateMapUpdater(state.mapState, action)
+      };
     }
   });


### PR DESCRIPTION
- Synchronizes kepler's mapState with hubble's whenever it is updated so that zoom-based scaling correctly applies to layers.

Supports keyframe definitions on scene now using special object keys.
Supported Keyframes (by key name):
- `camera`: mapState animation
- `hubble_timeFilter` applies time filter keyframe to first time filter listed in kepler. (only one filter is supported right now)
- any `visConfig` of a layer can by animated by using the layer's `label` as a key.

**This interface is very experimental, and will change.**