### PR TITLE
Kepler now external to worldview components

### DIFF
--- a/examples/worldview/src/app/App.js
+++ b/examples/worldview/src/app/App.js
@@ -30,7 +30,14 @@ const KEPLER_UI = {
   LoadingSpinner
 };
 import {Stage} from '../features/stage/Stage';
-import {useKepler, useKeplerKeyframes, usePrepareKeplerFrame} from '../features/kepler/hooks';
+import {
+  useKepler,
+  useKeplerDeckLayers,
+  useKeplerKeyframes,
+  usePrepareKeplerFrame,
+  createSelectMapStyle,
+  createSelectKeplerLayers
+} from '../features/kepler';
 
 import {useNewYorkScene} from '../scenes/newYork';
 
@@ -74,15 +81,26 @@ const WindowSize = styled.div`
   background-color: #0e0e10;
 `;
 
+const KEPLER_MAP_ID = 'map';
+const selectKeplerLayers = createSelectKeplerLayers(KEPLER_MAP_ID);
+const selectMapStyle = createSelectMapStyle(KEPLER_MAP_ID);
+
 const App = ({}) => {
   const ready = useSelector(state => state.hubbleGl.map.ready);
-  useKepler();
-  // TODO: kepler can be mounted at any location in redux.
-  const keplerLayers = useSelector(
-    state => state.keplerGl.map && state.keplerGl.map.visState.layers
-  );
+  useKepler(KEPLER_MAP_ID);
+  const keplerLayers = useSelector(selectKeplerLayers);
   const getKeyframes = useKeplerKeyframes(keplerLayers);
   const prepareFrame = usePrepareKeplerFrame(keplerLayers);
+
+  const deckLayers = useKeplerDeckLayers(KEPLER_MAP_ID);
+  const deckProps = {
+    layers: deckLayers
+  };
+  const mapStyle = useSelector(selectMapStyle);
+  const staticMapProps = {
+    mapStyle
+  };
+
   // const state = useSelector(state => state);
   // console.log(state);
 
@@ -97,7 +115,12 @@ const App = ({}) => {
               {ready && (
                 <>
                   <div style={{height: 1080, margin: 16}}>
-                    <Stage getKeyframes={getKeyframes} prepareFrame={prepareFrame} />
+                    <Stage
+                      getKeyframes={getKeyframes}
+                      prepareFrame={prepareFrame}
+                      deckProps={deckProps}
+                      staticMapProps={staticMapProps}
+                    />
                   </div>
                 </>
               )}

--- a/examples/worldview/src/features/kepler/hooks.js
+++ b/examples/worldview/src/features/kepler/hooks.js
@@ -1,18 +1,20 @@
-import {useEffect, useCallback} from 'react';
+import {useEffect, useCallback, useMemo} from 'react';
 import {registerEntry, setFilter, layerVisConfigChange} from 'kepler.gl/actions';
 import {FilterValueKeyframes, Keyframes} from '@hubble.gl/core';
 import {useDispatch, useSelector} from 'react-redux';
+import {createSelector} from 'reselect';
 
 import {filterKeyframeSelector, layerKeyframeSelector} from '../timeline/timelineSlice';
 import {AUTH_TOKENS} from '../../constants';
 import {updateViewState} from '../stage/mapSlice';
+import {createSelectKeplerMap} from './keplerSlice';
 
-export const useKepler = () => {
+export const useKepler = mapId => {
   const dispatch = useDispatch();
   useEffect(() => {
     dispatch(
       registerEntry({
-        id: 'map',
+        id: mapId,
         mint: true,
         mapboxApiAccessToken: AUTH_TOKENS.MAPBOX_TOKEN
         // mapboxApiUrl,
@@ -23,12 +25,13 @@ export const useKepler = () => {
   }, []);
 };
 
-export const useKeplerMapState = () => {
+export const useKeplerMapState = mapId => {
   const dispatch = useDispatch();
-  const keplerMapState = useSelector(state => state.keplerGl.map && state.keplerGl.map.mapState);
+  const selectKeplerMap = useMemo(() => createSelectKeplerMap(mapId), [mapId]);
+  const {mapState} = useSelector(selectKeplerMap);
   useEffect(() => {
-    if (keplerMapState) {
-      const {latitude, longitude, zoom, bearing, pitch, altitude} = keplerMapState;
+    if (mapState) {
+      const {latitude, longitude, zoom, bearing, pitch, altitude} = mapState;
       dispatch(
         updateViewState({
           latitude,
@@ -40,7 +43,7 @@ export const useKeplerMapState = () => {
         })
       );
     }
-  }, [keplerMapState]);
+  }, [mapState]);
 };
 
 export const useKeplerKeyframes = keplerLayers => {
@@ -107,4 +110,100 @@ export const usePrepareKeplerFrame = keplerLayers => {
   );
 
   return prepareFrame;
+};
+
+/**
+ * Kepler Layer Creation
+ * Forked from kepler.gl
+ * https://github.com/keplergl/kepler.gl/blob/master/src/components/map-container.js
+ */
+
+const layersSelector = state => state.visState.layers;
+const layerDataSelector = state => state.visState.layerData;
+const mapLayersSelector = state => state.visState.mapLayers;
+// const layerOrderSelector = state => state.visState.layerOrder;
+export const layersToRenderSelector = createSelector(
+  layersSelector,
+  layerDataSelector,
+  mapLayersSelector,
+  // {[id]: true \ false}
+  (layers, layerData, mapLayers) =>
+    layers.reduce(
+      (accu, layer, idx) => ({
+        ...accu,
+        [layer.id]: layer.shouldRenderLayer(layerData[idx]) && _isVisibleMapLayer(layer, mapLayers) // eslint-disable-line
+      }),
+      {}
+    )
+);
+/* component private functions */
+function _isVisibleMapLayer(layer, mapLayers) {
+  // if layer.id is not in mapLayers, don't render it
+  return !mapLayers || (mapLayers && mapLayers[layer.id]);
+}
+function _onLayerSetDomain(idx, colorDomain) {
+  // TODO: this isn't dispatched to the redux store yet.
+  // layerConfigChange(this.props.mapData.visState.layers[idx], {
+  //   colorDomain
+  // });
+}
+
+export const useKeplerDeckLayers = mapId => {
+  const selectKeplerMap = useMemo(() => createSelectKeplerMap(mapId), [mapId]);
+  const map = useSelector(selectKeplerMap);
+
+  const renderLayer = useCallback(
+    (overlays, idx) => {
+      const {
+        visState: {
+          datasets,
+          layers,
+          layerData,
+          hoverInfo,
+          clicked,
+          interactionConfig,
+          animationConfig
+        },
+        mapState
+      } = map;
+
+      const layer = layers[idx];
+      const data = layerData[idx];
+      const {gpuFilter} = datasets[layer.config.dataId] || {};
+
+      const objectHovered = clicked || hoverInfo;
+      const layerCallbacks = {
+        onSetLayerDomain: val => _onLayerSetDomain(idx, val)
+      };
+
+      // Layer is Layer class
+      const layerOverlay = layer.renderLayer({
+        data,
+        gpuFilter,
+        idx,
+        interactionConfig,
+        layerCallbacks,
+        mapState,
+        animationConfig,
+        objectHovered
+      });
+      return overlays.concat(layerOverlay || []);
+    },
+    [map]
+  );
+
+  return useMemo(() => {
+    if (!map) return [];
+    const layersToRender = layersToRenderSelector(map);
+    // returns an arr of DeckGL layer objects
+    const {layerOrder, layerData, layers} = map.visState;
+    if (layerData && layerData.length) {
+      return layerOrder
+        .slice()
+        .reverse()
+        .filter(idx => layers[idx].overlayType === 'deckgl' && layersToRender[layers[idx].id])
+        .reduce(renderLayer, []); // Slicing & reversing to create same layer order as Kepler
+    }
+    return [];
+  }, [map]);
 };

--- a/examples/worldview/src/features/kepler/index.js
+++ b/examples/worldview/src/features/kepler/index.js
@@ -1,0 +1,3 @@
+export {useKepler, useKeplerDeckLayers, useKeplerKeyframes, usePrepareKeplerFrame} from './hooks';
+
+export {createSelectMapStyle, createSelectKeplerLayers} from './keplerSlice';

--- a/examples/worldview/src/features/kepler/keplerSlice.js
+++ b/examples/worldview/src/features/kepler/keplerSlice.js
@@ -65,3 +65,30 @@ export default keplerGlReducer
       };
     }
   });
+
+const isKeplerReady = (state, mapId) => {
+  if (state.keplerGl[mapId]) return true;
+  return false;
+};
+
+export const createSelectKeplerLayers = mapId => {
+  return state => {
+    if (!isKeplerReady(state, mapId)) return undefined;
+    return state.keplerGl[mapId].visState.layers;
+  };
+};
+
+export const createSelectKeplerMap = mapId => {
+  return state => {
+    if (!isKeplerReady(state, mapId)) return undefined;
+    return state.keplerGl[mapId];
+  };
+};
+
+export const createSelectMapStyle = mapId => {
+  return state => {
+    if (!isKeplerReady(state, mapId)) return undefined;
+    const mapStyle = state.keplerGl[mapId].mapStyle;
+    return mapStyle.mapStyles[mapStyle.styleType].url;
+  };
+};

--- a/examples/worldview/src/features/stage/StageContainer.js
+++ b/examples/worldview/src/features/stage/StageContainer.js
@@ -59,7 +59,6 @@ export class StageContainer extends Component {
   render() {
     const {
       // state
-      mapData,
       viewState,
       dimension,
       // actions
@@ -82,7 +81,6 @@ export class StageContainer extends Component {
         width={width}
         height={height}
         // Map Props
-        mapData={mapData}
         viewState={viewState}
         setViewState={vs => dispatch(updateViewState(vs))}
         // Hubble Props
@@ -103,8 +101,7 @@ const mapStateToProps = state => {
   return {
     dimension: dimensionSelector(state),
     viewState: viewStateSelector(state),
-    duration: durationSelector(state),
-    mapData: state.keplerGl.map
+    duration: durationSelector(state)
   };
 };
 


### PR DESCRIPTION
- useKeplerDeckLayers hook to create deck layers from kepler redux store.
- selectMapStyle selector to inject map style from kepler redux store.
- kepler selectors support any "store map id" with createSelectKeplerLayers, createSelectKeplerMap, createSelectMapStyle.
- TODO: match kepler.gl layer creation better.