### PR TITLE
[bug fix] odd dimensions cause encoder issues

### DIFF
--- a/examples/worldview/src/features/stage/Stage.js
+++ b/examples/worldview/src/features/stage/Stage.js
@@ -12,6 +12,7 @@ import {AutoSizer} from 'react-virtualized';
 import {WithKeplerUI} from '@hubble.gl/react';
 import StageContainer from './StageContainer';
 import {useCameraKeyframes, usePrepareCameraFrame} from '../timeline/hooks';
+import {nearestEvenInt} from './utils';
 
 const StageBottomToolbar = ({playing, onPreview}) => {
   return (
@@ -71,7 +72,10 @@ const AutoSizeStage = ({children}) => {
     (availableWidth, availableHeight) => {
       const scale = Math.min(availableWidth / dimension.width, availableHeight / dimension.height);
 
-      return {mapWidth: dimension.width * scale, mapHeight: dimension.height * scale};
+      return {
+        mapWidth: nearestEvenInt(dimension.width * scale),
+        mapHeight: nearestEvenInt(dimension.height * scale)
+      };
     },
     [dimension]
   );
@@ -80,7 +84,12 @@ const AutoSizeStage = ({children}) => {
     <AutoSizer>
       {({width, height}) => {
         const {mapWidth, mapHeight} = getMapDimensions(width, height);
-        return children({mapHeight, mapWidth, availableHeight: height, availableWidth: width});
+        return children({
+          mapHeight,
+          mapWidth,
+          availableHeight: nearestEvenInt(height),
+          availableWidth: nearestEvenInt(width)
+        });
       }}
     </AutoSizer>
   );

--- a/examples/worldview/src/features/stage/Stage.js
+++ b/examples/worldview/src/features/stage/Stage.js
@@ -12,7 +12,7 @@ import {AutoSizer} from 'react-virtualized';
 import {WithKeplerUI} from '@hubble.gl/react';
 import StageContainer from './StageContainer';
 import {useCameraKeyframes, usePrepareCameraFrame} from '../timeline/hooks';
-import {nearestEvenInt} from './utils';
+import {nearestEven} from './utils';
 
 const StageBottomToolbar = ({playing, onPreview}) => {
   return (
@@ -73,8 +73,8 @@ const AutoSizeStage = ({children}) => {
       const scale = Math.min(availableWidth / dimension.width, availableHeight / dimension.height);
 
       return {
-        mapWidth: nearestEvenInt(dimension.width * scale),
-        mapHeight: nearestEvenInt(dimension.height * scale)
+        mapWidth: nearestEven(dimension.width * scale, 0),
+        mapHeight: nearestEven(dimension.height * scale, 0)
       };
     },
     [dimension]
@@ -87,8 +87,8 @@ const AutoSizeStage = ({children}) => {
         return children({
           mapHeight,
           mapWidth,
-          availableHeight: nearestEvenInt(height),
-          availableWidth: nearestEvenInt(width)
+          availableHeight: nearestEven(height, 0),
+          availableWidth: nearestEven(width, 0)
         });
       }}
     </AutoSizer>

--- a/examples/worldview/src/features/stage/StageMap.js
+++ b/examples/worldview/src/features/stage/StageMap.js
@@ -22,7 +22,7 @@ import React, {Component} from 'react';
 import DeckGL from '@deck.gl/react';
 import {StaticMap} from 'react-map-gl';
 import {MapboxLayer} from '@deck.gl/mapbox';
-import {nearestEvenFloat} from './utils';
+import {nearestEven} from './utils';
 
 export class StageMap extends Component {
   constructor(props) {
@@ -55,7 +55,7 @@ export class StageMap extends Component {
 
   _resizeVideo() {
     const {width, dimension} = this.props;
-    this._setDevicePixelRatio(nearestEvenFloat(dimension.width / width));
+    this._setDevicePixelRatio(nearestEven(dimension.width / width));
     if (this.mapRef.current) {
       const map = this.mapRef.current.getMap();
       map.resize();

--- a/examples/worldview/src/features/stage/StageMap.js
+++ b/examples/worldview/src/features/stage/StageMap.js
@@ -22,6 +22,7 @@ import React, {Component} from 'react';
 import DeckGL from '@deck.gl/react';
 import {StaticMap} from 'react-map-gl';
 import {MapboxLayer} from '@deck.gl/mapbox';
+import {nearestEvenFloat} from './utils';
 
 export class StageMap extends Component {
   constructor(props) {
@@ -54,7 +55,7 @@ export class StageMap extends Component {
 
   _resizeVideo() {
     const {width, dimension} = this.props;
-    this._setDevicePixelRatio(dimension.width / width);
+    this._setDevicePixelRatio(nearestEvenFloat(dimension.width / width));
     if (this.mapRef.current) {
       const map = this.mapRef.current.getMap();
       map.resize();

--- a/examples/worldview/src/features/stage/utils.js
+++ b/examples/worldview/src/features/stage/utils.js
@@ -1,7 +1,8 @@
 export const nearestEvenInt = num => 2 * Math.round(num / 2);
 
-export const nearestEvenFloat = num => {
-  num = num * 1000;
+export const nearestEvenFloat = (num, decimalPlaces = 3) => {
+  const factorTen = Math.pow(10, decimalPlaces);
+  num = num * factorTen;
   num = 2 * Math.round(num / 2);
-  return num / 1000;
+  return num / factorTen;
 };

--- a/examples/worldview/src/features/stage/utils.js
+++ b/examples/worldview/src/features/stage/utils.js
@@ -1,0 +1,7 @@
+export const nearestEvenInt = num => 2 * Math.round(num / 2);
+
+export const nearestEvenFloat = num => {
+  num = num * 1000;
+  num = 2 * Math.round(num / 2);
+  return num / 1000;
+};

--- a/examples/worldview/src/features/stage/utils.js
+++ b/examples/worldview/src/features/stage/utils.js
@@ -1,6 +1,4 @@
-export const nearestEvenInt = num => 2 * Math.round(num / 2);
-
-export const nearestEvenFloat = (num, decimalPlaces = 3) => {
+export const nearestEven = (num, decimalPlaces = 3) => {
   const factorTen = Math.pow(10, decimalPlaces);
   num = num * factorTen;
   num = 2 * Math.round(num / 2);


### PR DESCRIPTION
Video dimensions cannot be odd in many video formats. Solution: Round scaling factors to the closest even factor to always get an even resolution in the final video. [Any number multiplied by 2 is even.](https://www.theguardian.com/notesandqueries/query/0,5753,-2212,00.html#:~:text=EVEN%20NUMBERS%20can%20be%20looked,can%20be%20described%20as%202n.&text=Therefore%2C%20any%20even%20number%20plus,some%20number%20multiplied%20by%20two)

The ratio is a scaling factor and uses float (e.g. 1.345), whereas the dimensions represent pixels and those should be int (e.g. 1080 or 720).