### PR TITLE
[feat] add tripLayerKeyframe for Kepler Trip Layer support

### DIFF
--- a/examples/worldview/src/features/kepler/hooks.js
+++ b/examples/worldview/src/features/kepler/hooks.js
@@ -66,7 +66,7 @@ export const useKeplerKeyframes = keplerLayers => {
   const getKeplerKeyframes = useCallback(() => {
     let keyframes = {};
     if (tripLayerKeyframe) {
-      keyframes.kepler_tripLayer = new Keyframes(tripLayerKeyframe);
+      keyframes.kepler_tripLayer = new Keyframes({features: ['time'], ...tripLayerKeyframe});
     }
 
     if (Object.keys(layerKeyframe).length > 0) {

--- a/examples/worldview/src/features/kepler/hooks.js
+++ b/examples/worldview/src/features/kepler/hooks.js
@@ -1,5 +1,10 @@
 import {useEffect, useCallback, useMemo} from 'react';
-import {registerEntry, setFilter, layerVisConfigChange} from 'kepler.gl/actions';
+import {
+  registerEntry,
+  setFilter,
+  layerVisConfigChange,
+  setLayerAnimationTime
+} from 'kepler.gl/actions';
 import {FilterValueKeyframes, Keyframes} from '@hubble.gl/core';
 import {useDispatch, useSelector} from 'react-redux';
 import {createSelector} from 'reselect';
@@ -7,7 +12,8 @@ import {createSelector} from 'reselect';
 import {
   filterKeyframeSelector,
   layerKeyframeSelector,
-  frameSelector
+  frameSelector,
+  tripLayerKeyframeSelector
 } from '../timeline/timelineSlice';
 import {AUTH_TOKENS} from '../../constants';
 import {updateViewState} from '../map';
@@ -55,9 +61,14 @@ export const useKeplerMapState = mapId => {
 export const useKeplerKeyframes = keplerLayers => {
   const filterKeyframe = useSelector(filterKeyframeSelector);
   const layerKeyframe = useSelector(layerKeyframeSelector);
+  const tripLayerKeyframe = useSelector(tripLayerKeyframeSelector);
 
   const getKeplerKeyframes = useCallback(() => {
     let keyframes = {};
+    if (tripLayerKeyframe) {
+      // console.log(tripLayerKeyframe)
+      keyframes.kepler_tripLayer = new Keyframes(tripLayerKeyframe);
+    }
 
     if (Object.keys(layerKeyframe).length > 0) {
       keyframes = Object.entries(layerKeyframe).reduce((acc, [key, value]) => {
@@ -65,10 +76,11 @@ export const useKeplerKeyframes = keplerLayers => {
         const matchedLayer = keplerLayers.find(layer => layer.config.label === value.label);
         if (matchedLayer) {
           const features = Object.keys(matchedLayer.config.visConfig);
-          acc[key] = new Keyframes({...value, features});
-        } else {
-          throw new Error(`Error making kepler layer keyframe. Layer not found: '${value.label}'`);
+          acc[`kepler_${key}`] = new Keyframes({...value, features});
         }
+        // else {
+        //   throw new Error(`Error making kepler layer keyframe. Layer not found: '${value.label}'`);
+        // }
         return acc;
       }, keyframes);
     }
@@ -78,7 +90,7 @@ export const useKeplerKeyframes = keplerLayers => {
       keyframes.kepler_timeFilter = new FilterValueKeyframes(filterKeyframe);
     }
     return keyframes;
-  }, [filterKeyframe, layerKeyframe, keplerLayers]);
+  }, [filterKeyframe, layerKeyframe, tripLayerKeyframe, keplerLayers]);
 
   return getKeplerKeyframes;
 };
@@ -103,6 +115,10 @@ export const useKeplerFrame = (keplerLayers = []) => {
         dispatch(layerVisConfigChange(layer, keyframe));
       }
     });
+
+    if (frame.kepler_tripLayer) {
+      dispatch(setLayerAnimationTime(frame.kepler_tripLayer.time));
+    }
 
     // Note: Map State is kept in sync using plugin.
   }, [frame]);

--- a/examples/worldview/src/features/kepler/hooks.js
+++ b/examples/worldview/src/features/kepler/hooks.js
@@ -66,7 +66,6 @@ export const useKeplerKeyframes = keplerLayers => {
   const getKeplerKeyframes = useCallback(() => {
     let keyframes = {};
     if (tripLayerKeyframe) {
-      // console.log(tripLayerKeyframe)
       keyframes.kepler_tripLayer = new Keyframes(tripLayerKeyframe);
     }
 
@@ -78,9 +77,6 @@ export const useKeplerKeyframes = keplerLayers => {
           const features = Object.keys(matchedLayer.config.visConfig);
           acc[`kepler_${key}`] = new Keyframes({...value, features});
         }
-        // else {
-        //   throw new Error(`Error making kepler layer keyframe. Layer not found: '${value.label}'`);
-        // }
         return acc;
       }, keyframes);
     }

--- a/examples/worldview/src/features/timeline/timelineSlice.js
+++ b/examples/worldview/src/features/timeline/timelineSlice.js
@@ -4,6 +4,7 @@ import {createSlice} from '@reduxjs/toolkit';
 const initialState = {
   cameraKeyframes: undefined, // keyframe object
   filterKeyframes: undefined, // keyframe object
+  tripLayerKeyframes: undefined, // keyframe object
   layerKeyframes: {}, // name: keyframe object
   frame: {}
 };
@@ -14,6 +15,7 @@ const timelineSlice = createSlice({
   reducers: {
     updateCameraKeyframes: (state, action) => void (state.cameraKeyframes = action.payload),
     updateFilterKeyframes: (state, action) => void (state.filterKeyframes = action.payload),
+    updateTripLayerKeyframes: (state, action) => void (state.tripLayerKeyframes = action.payload),
     updateLayerKeyframes: (state, action) =>
       void (state.layerKeyframes = {...state.layerKeyframes, ...action.payload}),
     updateFrame: (state, action) => void (state.frame = action.payload)
@@ -24,6 +26,7 @@ export const {
   updateCameraKeyframes,
   updateFilterKeyframes,
   updateLayerKeyframes,
+  updateTripLayerKeyframes,
   updateFrame
 } = timelineSlice.actions;
 
@@ -35,5 +38,6 @@ export default timelineSlice.reducer;
 
 export const cameraKeyframeSelector = state => state.hubbleGl.timeline.cameraKeyframes;
 export const filterKeyframeSelector = state => state.hubbleGl.timeline.filterKeyframes;
+export const tripLayerKeyframeSelector = state => state.hubbleGl.timeline.tripLayerKeyframes;
 export const layerKeyframeSelector = state => state.hubbleGl.timeline.layerKeyframes;
 export const frameSelector = state => state.hubbleGl.timeline.frame;


### PR DESCRIPTION
When a kepler json with an active trip layer is loaded, the `setLayerAnimationTime` can be animated with keyframes stored in redux using the following action. Applying the animation happens automatically within the worldview kepler hook.

Usage in user code:
```
dispatch(updateTripLayerKeyframes({
  timings: [0, 1000, 2000],
  keyframes: [
    {time: 1671000000000},
    {time: 1671001000000},
    {time: 1671002000000}
  ],
  easings: easing.linear
}));
```