### PR TITLE
[refactor] Remove duration, use timecode instead

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,9 +54,8 @@ export function getCameraKeyframes() {
 }
 
 export function getDeckScene(animationLoop) {
-  const lengthMs = 5000;
   const data = [{sourcePosition: [-122.41669, 37.7853], targetPosition: [-122.41669, 37.781]}];
-  return new DeckScene({animationLoop, data, lengthMs, width: 1920, height: 1080});
+  return new DeckScene({animationLoop, data, width: 1920, height: 1080});
 }
 ```
 
@@ -72,8 +71,9 @@ import {DeckAdapter} from 'hubble.gl';
 import {useNextFrame, BasicControls} from '@hubble.gl/react';
 import {getDeckScene, getCameraKeyframes} from './scene';
 
-/** @type {import('@hubble.gl/core/src/types').FrameEncoderSettings} */
-const encoderSettings = {
+const timecode = {
+  start: 0,
+  end: 5000,
   framerate: 30
 }
 
@@ -90,7 +90,7 @@ export default function App() {
         ref={deckRef}
         {...adapter.getProps({deckRef, setReady, onNextFrame})}
       />
-      <div style={{position: 'absolute'}}>{ready && <BasicControls adapter={adapter} busy={busy} setBusy={setBusy} encoderSettings={encoderSettings} getCameraKeyframes={getCameraKeyframes}/>}</div>
+      <div style={{position: 'absolute'}}>{ready && <BasicControls adapter={adapter} busy={busy} setBusy={setBusy} timecode={timecode} getCameraKeyframes={getCameraKeyframes}/>}</div>
     </div>
   );
 }

--- a/modules/core/docs/deck-adapter.md
+++ b/modules/core/docs/deck-adapter.md
@@ -63,6 +63,12 @@ Provide a FrameEncoder class for capturing deck canvas. See [Encoders Overview](
 
 See [FrameEncoder](/modules/core/docs/encoder/frame-encoder#constructor-1) for internal defaults.
 
+* **`timecode` (`{start: number, end: number, framerate: number}`)**
+
+The start and end time in milliseconds to render, as well as a framerate.
+          
+* **`filename` (`string`, Optional) - Default: UUID.**
+
 * **`onStop` (`() => void`, Optional) - Default: `undefined`.**
 
 ##### `stop(callback)`

--- a/modules/core/docs/encoder/frame-encoder.md
+++ b/modules/core/docs/encoder/frame-encoder.md
@@ -8,12 +8,6 @@ Parameters:
 
 * `settings` (Object)
 
-  * `startOffsetMs` (`number`, Optional) - Offset the animation. Defaults to 0.
-
-  * `durationMs` (`number`, Optional) - Set to render a smaller duration than the whole clip. Defaults to scene length.
-
-  * `filename`(`string`, Optional) - Filename for rendered video. Defaults to UUID.
-
   * `framerate` (`number`, Optional) - framerate of rendered video. Defaults to 30.
 
 See encoders for additional namespaced settings.

--- a/modules/core/docs/scene/deck-scene.md
+++ b/modules/core/docs/scene/deck-scene.md
@@ -3,7 +3,6 @@
 ## Usage
 
 ```js
-const lengthMs = 5000;
 const width = 1280;
 const height = 720;
 
@@ -29,7 +28,6 @@ const getLayers = (scene) => {
 
 const scene = new DeckScene({
   animationLoop,  
-  lengthMs, 
   data,          // optional
   width,         // optional
   height         // optional
@@ -39,7 +37,7 @@ const scene = new DeckScene({
 ## Constructor
 
 ```js
-new DeckScene({animationLoop, length, keyframes, data});
+new DeckScene({animationLoop, keyframes, data});
 ```
 
 Parameters:
@@ -47,10 +45,6 @@ Parameters:
 ##### `animationLoop` (Object)
 
 A lumagl `animationLoop` object.
-
-##### `lengthMs` (Number)
-
-Total length of scene in milliseconds.
 
 ##### `data` (Object, Optional)
 

--- a/modules/core/src/adapters/deck-adapter.js
+++ b/modules/core/src/adapters/deck-adapter.js
@@ -113,13 +113,17 @@ export default class DeckAdapter {
    * @param {typeof import('../encoders').FrameEncoder} params.Encoder
    * @param {import('types').FrameEncoderSettings} params.encoderSettings
    * @param {() => void} params.onStop
+   * @param {string} params.filename
+   * @param {{start: number, end: number, framerate: number}} params.timecode
    */
   render({
     getCameraKeyframes = undefined,
     getKeyframes = undefined,
     Encoder = PreviewEncoder,
     encoderSettings = {},
-    onStop = undefined
+    onStop = undefined,
+    filename = undefined,
+    timecode = {start: 0, end: 0, framerate: 30}
   }) {
     if (getCameraKeyframes) {
       this.scene.setCameraKeyframes(getCameraKeyframes());
@@ -135,8 +139,8 @@ export default class DeckAdapter {
       }
     };
     this.shouldAnimate = true;
-    this.videoCapture.render(Encoder, encoderSettings, this.scene.lengthMs, innerOnStop);
-    this.scene.animationLoop.timeline.setTime(this.videoCapture.encoderSettings.startOffsetMs);
+    this.videoCapture.render(Encoder, encoderSettings, timecode, filename, innerOnStop);
+    this.scene.animationLoop.timeline.setTime(timecode.start);
     this.enabled = true;
   }
 

--- a/modules/core/src/capture/video-capture.js
+++ b/modules/core/src/capture/video-capture.js
@@ -31,25 +31,18 @@ export class VideoCapture {
   capturing;
   /** @type {number} */
   timeMs;
-  /** @type {number} */
-  endTimeMs;
-  /** @type {number} */
-  durationMs;
-  /** @type {number} */
-  framerate;
+  /** @type {{start: number, end: number, duration: number, framerate: number}} */
+  timecode;
   /** @type {FrameEncoder} */
   encoder;
   /** @type {string} */
   filename;
-  /** @type {import('types').FrameEncoderSettings} */
-  encoderSettings;
 
   constructor() {
     this.recording = false;
     this.capturing = false;
     this.timeMs = 0;
     this.encoder = null;
-    this.encoderSettings = null;
 
     this._getNextTimeMs = this._getNextTimeMs.bind(this);
     this._step = this._step.bind(this);
@@ -58,44 +51,6 @@ export class VideoCapture {
     this.render = this.render.bind(this);
     this.stop = this.stop.bind(this);
     this.save = this.save.bind(this);
-  }
-
-  /**
-   * @param {import('types').FrameEncoderSettings} encoderSettings
-   * @param {number} sceneLengthMs
-   */
-  parseEncoderSettings(encoderSettings, sceneLengthMs) {
-    const parsedSettings = {...encoderSettings};
-
-    if (!parsedSettings.startOffsetMs) {
-      parsedSettings.startOffsetMs = 0;
-    }
-    this.timeMs = parsedSettings.startOffsetMs;
-
-    if (parsedSettings.durationMs) {
-      this.endTimeMs = parsedSettings.startOffsetMs + parsedSettings.durationMs;
-    } else {
-      parsedSettings.durationMs = sceneLengthMs - parsedSettings.startOffsetMs;
-      this.endTimeMs = sceneLengthMs;
-    }
-    if (this.endTimeMs > sceneLengthMs) {
-      throw new Error(
-        `Recording end time (${this.endTimeMs}) cannot be greater then scene length (${sceneLengthMs})`
-      );
-    }
-    if (parsedSettings.durationMs <= 0) {
-      throw new Error(
-        `Invalid recording length in ms (${parsedSettings.durationMs}).  Must be greater than 0.`
-      );
-    }
-    this.durationMs = parsedSettings.durationMs;
-
-    if (!parsedSettings.filename) {
-      parsedSettings.filename = guid();
-    }
-    this.filename = parsedSettings.filename;
-
-    return parsedSettings;
   }
 
   // True if recording, false otherwise.
@@ -107,16 +62,17 @@ export class VideoCapture {
    * Start recording.
    * @param {typeof FrameEncoder} Encoder
    * @param {import('types').FrameEncoderSettings} encoderSettings
-   * @param {number} sceneLengthMs
+   * @param {{start: number, end: number, framerate: number, duration?: number}} timecode
    * @param {() => void} onStop
    */
-  render(Encoder, encoderSettings, sceneLengthMs, onStop = undefined) {
+  render(Encoder, encoderSettings, timecode, filename = undefined, onStop = undefined) {
     if (!this.isRecording()) {
       console.time('render');
-      this.encoderSettings = this.parseEncoderSettings(encoderSettings, sceneLengthMs);
-      console.log(`Starting recording for ${this.durationMs}ms.`);
+      this.filename = this._sanitizeFilename(filename);
+      this.timecode = this._sanatizeTimecode(timecode);
+      console.log(`Starting recording for ${this.timecode.duration}ms.`);
       this.onStop = onStop;
-      this.encoder = new Encoder(this.encoderSettings);
+      this.encoder = new Encoder({...encoderSettings, framerate: this.timecode.framerate});
       this.recording = true;
       this.encoder.start();
     }
@@ -139,7 +95,7 @@ export class VideoCapture {
       this._capture(canvas).then(data => {
         this.capturing = false;
         if (data.kind === 'step') {
-          console.log(`data.nextTimeMs: ${data.nextTimeMs}`);
+          // console.log(`data.nextTimeMs: ${data.nextTimeMs}`);
           proceedToNextFrame(data.nextTimeMs);
         } else if (data.error === 'STOP') {
           console.log('data.error: STOP');
@@ -157,14 +113,14 @@ export class VideoCapture {
    */
   stop(callback = undefined) {
     if (this.isRecording()) {
-      console.log(`Stopping recording.  Recorded for ${this.durationMs}ms.`);
+      console.log(`Stopping recording.  Recorded for ${this.timecode.duration}ms.`);
       this.recording = false;
       this.capturing = false; // Added to fix an intermittent bug
-      this.encoderSettings = null;
       this.save().then(() => {
         if (callback) {
           // eslint-disable-next-line callback-return
           callback();
+          this.timecode = null;
         }
       });
     }
@@ -192,6 +148,42 @@ export class VideoCapture {
   }
 
   /**
+   * @param {string} filename
+   */
+  _sanitizeFilename(filename) {
+    if (!filename) {
+      filename = guid();
+    }
+    return filename;
+  }
+
+  /**
+   * @param {{start: number, end: number, framerate: number, duration?: number}} timecode
+   */
+  _sanatizeTimecode(timecode) {
+    const parsedTimecode = {
+      duration: undefined,
+      ...timecode
+    };
+
+    if (!parsedTimecode.start) {
+      parsedTimecode.start = 0;
+    }
+    this.timeMs = parsedTimecode.start;
+
+    if (!parsedTimecode.duration) {
+      parsedTimecode.duration = parsedTimecode.end - parsedTimecode.start;
+    }
+
+    if (parsedTimecode.duration <= 0) {
+      throw new Error(
+        `Invalid recording length (${parsedTimecode.duration}ms).  Must be greater than 0.`
+      );
+    }
+    return parsedTimecode;
+  }
+
+  /**
    * Capture the current canvas.
    * @param {HTMLCanvasElement} canvas
    * @returns {Promise<import('types').CaptureStep>}
@@ -214,7 +206,7 @@ export class VideoCapture {
   _step() {
     // generating next frame timestamp
     this.timeMs = this._getNextTimeMs();
-    if (this.timeMs > this.endTimeMs) {
+    if (this.timeMs > this.timecode.end) {
       return {kind: 'error', error: 'STOP'};
     }
     return {kind: 'step', nextTimeMs: this.timeMs};
@@ -223,7 +215,7 @@ export class VideoCapture {
   // Get next time MS based on current time MS and framerate
   // @return time in milliseconds for next frame.
   _getNextTimeMs() {
-    const frameLengthMs = parseInt(1000.0 / this.encoder.framerate, 10);
+    const frameLengthMs = Math.floor(1000.0 / this.timecode.framerate);
     return this.timeMs + frameLengthMs;
   }
 }

--- a/modules/core/src/scene/deck-scene.js
+++ b/modules/core/src/scene/deck-scene.js
@@ -19,10 +19,9 @@
 // THE SOFTWARE.
 export default class DeckScene {
   /** @param {import('types').DeckSceneParams} params */
-  constructor({animationLoop, data, lengthMs, width, height, initialKeyframes = undefined}) {
+  constructor({animationLoop, data, width, height, initialKeyframes = undefined}) {
     this.animationLoop = animationLoop;
     this.data = data;
-    this.lengthMs = lengthMs;
     this.width = width;
     this.height = height;
 
@@ -33,10 +32,6 @@ export default class DeckScene {
     }
 
     this.setCameraKeyframes = this.setCameraKeyframes.bind(this);
-  }
-
-  setDuration(duration) {
-    this.lengthMs = duration;
   }
 
   setCameraKeyframes(cameraKeyframes) {

--- a/modules/core/src/types.d.ts
+++ b/modules/core/src/types.d.ts
@@ -26,9 +26,6 @@ type DeckGl = {
 type FrameEncoderSettings = Partial<EncoderSettings>
 
 interface EncoderSettings {
-  startOffsetMs?: number
-  durationMs?: number
-  filename: string
   framerate: number
   jpeg: {
     quality: number


### PR DESCRIPTION
```
timecode = {
  start?: number, // default 0
  end: number,
  framerate?: number // default 30
  duration?: number // end - start
}
```
- Timecode can be used to for partial previews and renders by specifying any start or end time in the animation.
  - Previously the duration parameter assumed every render and preview started at time zero.
- framerate has been moved from encoderSettings to timecode.
- filename has been moved out of encoderSettings as well.
- lengthMs has been removed from DeskScene. Just supply timecode instead.