### PR TITLE
[chore] rename encoderSettings to formatConfigs

### DIFF
--- a/examples/camera/app.js
+++ b/examples/camera/app.js
@@ -17,8 +17,8 @@ const INITIAL_VIEW_STATE = {
   maxPitch: 90
 };
 
-/** @type {import('@hubble.gl/core/src/types').FrameEncoderSettings} */
-const encoderSettings = {
+/** @type {import('@hubble.gl/core/src/types').FormatConfigs} */
+const formatConfigs = {
   webm: {
     quality: 0.8
   },
@@ -111,7 +111,7 @@ export default function App() {
             adapter={adapter}
             busy={busy}
             setBusy={setBusy}
-            encoderSettings={encoderSettings}
+            formatConfigs={formatConfigs}
             timecode={timecode}
             getCameraKeyframes={getCameraKeyframes}
             getKeyframes={getKeyframes}

--- a/examples/terrain/app.js
+++ b/examples/terrain/app.js
@@ -101,8 +101,8 @@ const getKeyframes = () => {
   };
 };
 
-/** @type {import('@hubble.gl/core/src/types').FrameEncoderSettings} */
-const encoderSettings = {
+/** @type {import('@hubble.gl/core/src/types').FormatConfigs} */
+const formatConfigs = {
   webm: {
     quality: 0.8
   },
@@ -178,7 +178,7 @@ export default function App() {
             adapter={adapter}
             busy={busy}
             setBusy={setBusy}
-            encoderSettings={encoderSettings}
+            formatConfigs={formatConfigs}
             timecode={timecode}
             getCameraKeyframes={getCameraKeyframes}
             getKeyframes={getKeyframes}

--- a/examples/trips/app.js
+++ b/examples/trips/app.js
@@ -69,8 +69,8 @@ const landCover = [
   ]
 ];
 
-/** @type {import('@hubble.gl/core/src/types').FrameEncoderSettings} */
-const encoderSettings = {
+/** @type {import('@hubble.gl/core/src/types').FormatConfigs} */
+const formatConfigs = {
   webm: {
     quality: 0.8
   },
@@ -247,7 +247,7 @@ export default function App({
             adapter={adapter}
             busy={busy}
             setBusy={setBusy}
-            encoderSettings={encoderSettings}
+            formatConfigs={formatConfigs}
             timecode={timecode}
             getCameraKeyframes={getCameraKeyframes}
           />

--- a/examples/worldview/src/features/renderer/rendererMiddleware.js
+++ b/examples/worldview/src/features/renderer/rendererMiddleware.js
@@ -60,7 +60,7 @@ export const rendererMiddleware = store => {
         adapter.render({
           getCameraKeyframes,
           Encoder: PreviewEncoder,
-          encoderSettings: formatConfigsSelector(state),
+          formatConfigs: formatConfigsSelector(state),
           timecode: timecodeSelector(state),
           filename: filenameSelector(state),
           onStop: innerOnStop,
@@ -83,7 +83,7 @@ export const rendererMiddleware = store => {
         adapter.render({
           getCameraKeyframes,
           Encoder,
-          encoderSettings: formatConfigsSelector(state),
+          formatConfigs: formatConfigsSelector(state),
           timecode: timecodeSelector(state),
           filename: filenameSelector(state),
           onStop: innerOnStop,

--- a/modules/core/docs/deck-adapter.md
+++ b/modules/core/docs/deck-adapter.md
@@ -41,7 +41,7 @@ Parameters:
 
 * `extraProps` (`DeckGlProps`, Optional) - Apply extra props to deckgl. Note: Hubble will override props as needed.
 
-##### `render({getCameraKeyframes, Encoder, encoderSettings, onStop, getKeyframes})`
+##### `render({getCameraKeyframes, Encoder, formatConfigs, onStop, getKeyframes})`
 
 Start rendering.
 
@@ -59,7 +59,7 @@ This function is called after the last frame is rendered and a file is created f
 
 Provide a FrameEncoder class for capturing deck canvas. See [Encoders Overview](/modules/core/docs/encoder) for options.
 
-* **`encoderSettings` (`Object`, Optional) - Default: `{}`.**
+* **`formatConfigs` (`Object`, Optional) - Default: `{}`.**
 
 See [FrameEncoder](/modules/core/docs/encoder/frame-encoder#constructor-1) for internal defaults.
 

--- a/modules/core/src/adapters/deck-adapter.js
+++ b/modules/core/src/adapters/deck-adapter.js
@@ -111,7 +111,7 @@ export default class DeckAdapter {
    * @param {() => import('../keyframes').CameraKeyframes} params.getCameraKeyframes
    * @param {() => Object<string, import('../keyframes').Keyframes>} params.getKeyframes
    * @param {typeof import('../encoders').FrameEncoder} params.Encoder
-   * @param {import('types').FrameEncoderSettings} params.encoderSettings
+   * @param {Partial<import('types').FormatConfigs>} params.formatConfigs
    * @param {() => void} params.onStop
    * @param {string} params.filename
    * @param {{start: number, end: number, framerate: number}} params.timecode
@@ -120,7 +120,7 @@ export default class DeckAdapter {
     getCameraKeyframes = undefined,
     getKeyframes = undefined,
     Encoder = PreviewEncoder,
-    encoderSettings = {},
+    formatConfigs = {},
     onStop = undefined,
     filename = undefined,
     timecode = {start: 0, end: 0, framerate: 30}
@@ -139,7 +139,7 @@ export default class DeckAdapter {
       }
     };
     this.shouldAnimate = true;
-    this.videoCapture.render(Encoder, encoderSettings, timecode, filename, innerOnStop);
+    this.videoCapture.render(Encoder, formatConfigs, timecode, filename, innerOnStop);
     this.scene.animationLoop.timeline.setTime(timecode.start);
     this.enabled = true;
   }

--- a/modules/core/src/capture/video-capture.js
+++ b/modules/core/src/capture/video-capture.js
@@ -61,18 +61,18 @@ export class VideoCapture {
   /**
    * Start recording.
    * @param {typeof FrameEncoder} Encoder
-   * @param {import('types').FrameEncoderSettings} encoderSettings
+   * @param {import('types').FormatConfigs} formatConfigs
    * @param {{start: number, end: number, framerate: number, duration?: number}} timecode
    * @param {() => void} onStop
    */
-  render(Encoder, encoderSettings, timecode, filename = undefined, onStop = undefined) {
+  render(Encoder, formatConfigs, timecode, filename = undefined, onStop = undefined) {
     if (!this.isRecording()) {
       console.time('render');
       this.filename = this._sanitizeFilename(filename);
       this.timecode = this._sanatizeTimecode(timecode);
       console.log(`Starting recording for ${this.timecode.duration}ms.`);
       this.onStop = onStop;
-      this.encoder = new Encoder({...encoderSettings, framerate: this.timecode.framerate});
+      this.encoder = new Encoder({...formatConfigs, framerate: this.timecode.framerate});
       this.recording = true;
       this.encoder.start();
     }

--- a/modules/core/src/types.d.ts
+++ b/modules/core/src/types.d.ts
@@ -25,8 +25,11 @@ type DeckGl = {
 
 type FrameEncoderSettings = Partial<EncoderSettings>
 
-interface EncoderSettings {
+interface EncoderSettings extends FormatConfigs {
   framerate: number
+}
+
+interface FormatConfigs {
   jpeg: {
     quality: number
   },
@@ -39,7 +42,7 @@ interface EncoderSettings {
     width: number,
     height: number
     jpegQuality: number
-  },
+  }
 }
 
 interface DeckSceneParams {

--- a/modules/react/src/components/basic-controls.js
+++ b/modules/react/src/components/basic-controls.js
@@ -40,7 +40,7 @@ export default function BasicControls({
   adapter,
   busy,
   setBusy,
-  encoderSettings,
+  formatConfigs,
   timecode,
   getCameraKeyframes,
   getKeyframes = undefined
@@ -52,7 +52,7 @@ export default function BasicControls({
       getCameraKeyframes,
       getKeyframes,
       Encoder: ENCODERS[encoder],
-      encoderSettings,
+      formatConfigs,
       timecode,
       onStop: () => setBusy(false)
     });

--- a/modules/react/src/components/export-video/export-video-panel-container.js
+++ b/modules/react/src/components/export-video/export-video-panel-container.js
@@ -35,15 +35,6 @@ import ExportVideoPanel from './export-video-panel';
 import {parseSetCameraType} from './utils';
 import {DEFAULT_FILENAME, getResolutionSetting} from './constants';
 
-// import {DEFAULT_TIME_FORMAT} from 'kepler.gl';
-// import moment from 'moment';
-
-// function setFileNameDeckAdapter(name) {
-//   encoderSettings.filename = `${name} ${moment()
-//     .format(DEFAULT_TIME_FORMAT)
-//     .toString()}`;
-// }
-
 const ENCODERS = {
   gif: GifEncoder,
   webm: WebMEncoder,
@@ -97,7 +88,7 @@ export class ExportVideoPanelContainer extends Component {
     return getResolutionSetting(resolution);
   }
 
-  getEncoderSettings() {
+  getFormatConfigs() {
     const {width, height} = this.getCanvasSize();
 
     return {
@@ -202,7 +193,7 @@ export class ExportVideoPanelContainer extends Component {
   onPreviewVideo() {
     const {adapter} = this.state;
     const filename = this.getFileName();
-    const encoderSettings = this.getEncoderSettings();
+    const formatConfigs = this.getFormatConfigs();
     const timecode = this.getTimecode();
     const onStop = () => {
       this.forceUpdate();
@@ -210,7 +201,7 @@ export class ExportVideoPanelContainer extends Component {
     adapter.render({
       getCameraKeyframes: this.getCameraKeyframes,
       Encoder: PreviewEncoder,
-      encoderSettings,
+      formatConfigs,
       timecode,
       filename,
       onStop
@@ -221,7 +212,7 @@ export class ExportVideoPanelContainer extends Component {
     const {adapter} = this.state;
     const filename = this.getFileName();
     const Encoder = this.getEncoder();
-    const encoderSettings = this.getEncoderSettings();
+    const formatConfigs = this.getFormatConfigs();
     const timecode = this.getTimecode();
 
     this.setState({rendering: true}); // Enables overlay after user clicks "Render"
@@ -232,7 +223,7 @@ export class ExportVideoPanelContainer extends Component {
     adapter.render({
       getCameraKeyframes: this.getCameraKeyframes,
       Encoder,
-      encoderSettings,
+      formatConfigs,
       timecode,
       filename,
       onStop

--- a/modules/react/src/components/quick-animation.js
+++ b/modules/react/src/components/quick-animation.js
@@ -13,7 +13,7 @@ export const QuickAnimation = ({
   timecode,
   width = 640,
   height = 480,
-  encoderSettings = {},
+  formatConfigs = {},
   deckProps = {}
 }) => {
   const deckRef = useRef(null);
@@ -34,7 +34,7 @@ export const QuickAnimation = ({
 
   const [adapter] = useState(new DeckAdapter(getDeckScene));
 
-  const mergedEncoderSettings = {
+  const mergedFormatConfigs = {
     webm: {
       quality: 0.8
     },
@@ -46,7 +46,7 @@ export const QuickAnimation = ({
       width,
       height
     },
-    ...encoderSettings
+    ...formatConfigs
   };
 
   const mergedTimecode = {
@@ -76,7 +76,7 @@ export const QuickAnimation = ({
             adapter={adapter}
             busy={busy}
             setBusy={setBusy}
-            encoderSettings={mergedEncoderSettings}
+            formatConfigs={mergedFormatConfigs}
             timecode={mergedTimecode}
             getCameraKeyframes={
               getCameraKeyframes ? () => getCameraKeyframes(viewState) : getCameraKeyframes


### PR DESCRIPTION
Formats can be configured with the following passed into `DeckAdapter.render({formatConfigs})`

```
interface FormatConfigs {
  jpeg: {
    quality: number
  },
  webm: {
    quality: number
  }
  gif: {
    numWorkers: number,
    sampleInterval: number,
    width: number,
    height: number
    jpegQuality: number
  }
}
```