### PR TITLE
[chore] use Timeline instead of AnimationLoop

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,9 +53,9 @@ export function getCameraKeyframes() {
   });
 }
 
-export function getDeckScene(animationLoop) {
+export function getDeckScene(timeline) {
   const data = [{sourcePosition: [-122.41669, 37.7853], targetPosition: [-122.41669, 37.781]}];
-  return new DeckScene({animationLoop, data, width: 1920, height: 1080});
+  return new DeckScene({timeline, data, width: 1920, height: 1080});
 }
 ```
 

--- a/examples/camera/app.js
+++ b/examples/camera/app.js
@@ -71,9 +71,9 @@ export default function App() {
     });
   }, [viewStateA, viewStateB]);
 
-  const getDeckScene = animationLoop => {
+  const getDeckScene = timeline => {
     return new DeckScene({
-      animationLoop,
+      timeline,
       width: 640,
       height: 480,
       initialKeyframes: getKeyframes()

--- a/examples/terrain/app.js
+++ b/examples/terrain/app.js
@@ -129,9 +129,9 @@ export default function App() {
   const onNextFrame = useNextFrame();
   const [rainbow, setRainbow] = useState(false);
 
-  const getDeckScene = animationLoop => {
+  const getDeckScene = timeline => {
     return new DeckScene({
-      animationLoop,
+      timeline,
       width: 640,
       height: 480,
       initialKeyframes: getKeyframes()

--- a/examples/trips/app.js
+++ b/examples/trips/app.js
@@ -117,9 +117,9 @@ export default function App({
   const [animation] = useState({});
   const [viewState, setViewState] = useState(INITIAL_VIEW_STATE);
 
-  const getDeckScene = animationLoop => {
+  const getDeckScene = timeline => {
     return new DeckScene({
-      animationLoop,
+      timeline,
       width: 1280,
       height: 720
     });

--- a/examples/worldview/src/features/map/MapContainer.js
+++ b/examples/worldview/src/features/map/MapContainer.js
@@ -42,9 +42,9 @@ export const MapContainer = ({
   const duration = useSelector(durationSelector);
 
   const getDeckScene = useCallback(
-    animationLoop => {
+    timeline => {
       return new DeckScene({
-        animationLoop,
+        timeline,
         lengthMs: duration,
         width: dimension.width,
         height: dimension.height

--- a/modules/core/docs/deck-adapter.md
+++ b/modules/core/docs/deck-adapter.md
@@ -8,18 +8,18 @@ new DeckAdapter(sceneBuilder);
 
 ## Parameters
 
-##### `sceneBuilder` (`(animationLoop) => Promise<DeckScene> | DeckScene`)
+##### `sceneBuilder` (`(timeline) => Promise<DeckScene> | DeckScene`)
 
 Function to build scene, async or sync. See [DeckScene](/modules/core/docs/scene/deck-scene) for more information.
 
 ```js
-async function sceneBuilder(animationLoop) {
+async function sceneBuilder(timeline) {
   // See DeckScene API Reference for more info
   const data = await fetch(...)
   const lengthMs = 5000 // ms
   const width = 1920 // px
   const height = 1080 // px
-  return new DeckScene({animationLoop, data, lengthMs, width, height})
+  return new DeckScene({timeline, data, lengthMs, width, height})
 }
 ```
 

--- a/modules/core/docs/keyframe/camera-keyframes.md
+++ b/modules/core/docs/keyframe/camera-keyframes.md
@@ -9,7 +9,7 @@ const keyframes = {
   camera: new CameraKeyframes({timings, keyframes, easings});
 }
 // Attach each keyframe object to timeline.
-animationLoop.timeline.attachAnimation(keyframes.camera);
+timeline.attachAnimation(keyframes.camera);
 ```
 
 ## Constructor

--- a/modules/core/docs/scene/deck-scene.md
+++ b/modules/core/docs/scene/deck-scene.md
@@ -11,7 +11,7 @@ const keyframes = {
   camera: new CameraKeyframes({...}) // camera is a reserved key
 }
 // Attach each keyframe object to timeline.
-animationLoop.timeline.attachAnimation(keyframes.camera);
+timeline.attachAnimation(keyframes.camera);
 
 // Optional unless animating deck.gl layer properties.
 const data = {
@@ -27,7 +27,7 @@ const getLayers = (scene) => {
 }
 
 const scene = new DeckScene({
-  animationLoop,  
+  timeline,  
   data,          // optional
   width,         // optional
   height         // optional
@@ -37,14 +37,14 @@ const scene = new DeckScene({
 ## Constructor
 
 ```js
-new DeckScene({animationLoop, keyframes, data});
+new DeckScene({timeline, keyframes, data});
 ```
 
 Parameters:
 
-##### `animationLoop` (Object)
+##### `timeline` (Object)
 
-A lumagl `animationLoop` object.
+A lumagl `timeline` object.
 
 ##### `data` (Object, Optional)
 
@@ -64,7 +64,7 @@ Returns:
 
 ##### `setKeyframes` (`Object`)
 
-Keyframe objects registered to the animationLoop timeline.
+Keyframe objects registered to the Timeline.
 
 - `camera` (`CameraKeyframes`, Optional) - supply a camera animation. If set, `deck.viewState` will be set with this keyframe object.
 

--- a/modules/core/src/adapters/deck-adapter.js
+++ b/modules/core/src/adapters/deck-adapter.js
@@ -26,7 +26,7 @@ import {VideoCapture} from '../capture/video-capture';
 export default class DeckAdapter {
   /** @type {DeckScene} */
   scene;
-  /** @type {(animationLoop: any) => Promise<DeckScene> | DeckScene} */
+  /** @type {(timeline: any) => Promise<DeckScene> | DeckScene} */
   sceneBuilder;
   /** @type {boolean} */
   shouldAnimate;
@@ -36,7 +36,7 @@ export default class DeckAdapter {
   glContext;
 
   /**
-   * @param {(animationLoop: any) => DeckScene | Promise<DeckScene>} sceneBuilder
+   * @param {(timeline: any) => DeckScene | Promise<DeckScene>} sceneBuilder
    * @param {WebGL2RenderingContext} glContext
    */
   constructor(sceneBuilder, glContext = undefined) {
@@ -140,7 +140,7 @@ export default class DeckAdapter {
     };
     this.shouldAnimate = true;
     this.videoCapture.render(Encoder, formatConfigs, timecode, filename, innerOnStop);
-    this.scene.animationLoop.timeline.setTime(timecode.start);
+    this.scene.timeline.setTime(timecode.start);
     this.enabled = true;
   }
 
@@ -167,18 +167,18 @@ export default class DeckAdapter {
       if (getKeyframes) {
         this.scene.setKeyframes(getKeyframes());
       }
-      this.scene.animationLoop.timeline.setTime(timeMs);
+      this.scene.timeline.setTime(timeMs);
     }
   }
 
   async _deckOnLoad(deck) {
     this.deck = deck;
 
-    const animationLoop = deck.animationLoop;
-    animationLoop.timeline.pause();
-    animationLoop.timeline.setTime(0);
+    const timeline = deck.animationLoop.timeline;
+    timeline.pause();
+    timeline.setTime(0);
 
-    await Promise.resolve(this.sceneBuilder(animationLoop)).then(scene => {
+    await Promise.resolve(this.sceneBuilder(timeline)).then(scene => {
       this._applyScene(scene);
     });
   }
@@ -208,7 +208,7 @@ export default class DeckAdapter {
    */
   onAfterRender(proceedToNextFrame) {
     this.videoCapture.capture(this.deck.canvas, nextTimeMs => {
-      this.scene.animationLoop.timeline.setTime(nextTimeMs);
+      this.scene.timeline.setTime(nextTimeMs);
       proceedToNextFrame(nextTimeMs);
     });
   }

--- a/modules/core/src/scene/deck-scene.js
+++ b/modules/core/src/scene/deck-scene.js
@@ -17,14 +17,16 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+import {Timeline} from '@luma.gl/engine';
+
 export default class DeckScene {
   /** @param {import('types').DeckSceneParams} params */
-  constructor({animationLoop, data, width, height, initialKeyframes = undefined}) {
-    this.animationLoop = animationLoop;
+  constructor({timeline, data, width, height, initialKeyframes = undefined}) {
     this.data = data;
     this.width = width;
     this.height = height;
 
+    this.timeline = timeline || new Timeline();
     this.keyframes = {};
     this.animations = {};
     if (initialKeyframes) {
@@ -43,11 +45,11 @@ export default class DeckScene {
     for (const keyframe in keyframes) {
       const animation = this.animations[keyframe];
       if (animation) {
-        this.animationLoop.timeline.detachAnimation(animation);
+        this.timeline.detachAnimation(animation);
       }
-      this.animations[keyframe] = this.animationLoop.timeline.attachAnimation(
-        this.keyframes[keyframe]
-      );
+      this.animations[keyframe] = this.timeline.attachAnimation(this.keyframes[keyframe]);
+    }
+  }
     }
   }
 }

--- a/modules/core/src/scene/deck-scene.js
+++ b/modules/core/src/scene/deck-scene.js
@@ -50,6 +50,4 @@ export default class DeckScene {
       this.animations[keyframe] = this.timeline.attachAnimation(this.keyframes[keyframe]);
     }
   }
-    }
-  }
 }

--- a/modules/core/src/scene/kepler-scene.js
+++ b/modules/core/src/scene/kepler-scene.js
@@ -19,8 +19,8 @@
 // THE SOFTWARE.
 export default class KeplerScene {
   /** @param {import('types').KeplerSceneParams} params */
-  constructor({animationLoop, keyframes, data, filters, getFrame, lengthMs, width, height}) {
-    this.animationLoop = animationLoop;
+  constructor({timeline, keyframes, data, filters, getFrame, lengthMs, width, height}) {
+    this.timeline = timeline;
     this.keyframes = keyframes;
     this.data = data;
     this._getFrame = getFrame;

--- a/modules/core/src/types.d.ts
+++ b/modules/core/src/types.d.ts
@@ -46,7 +46,7 @@ interface FormatConfigs {
 }
 
 interface DeckSceneParams {
-  animationLoop: any
+  timeline: any
   lengthMs: number
   width: number
   height: number
@@ -55,7 +55,7 @@ interface DeckSceneParams {
 }
 
 interface KeplerSceneParams {
-  animationLoop: any
+  timeline: any
   lengthMs: number
   width: number
   height: number

--- a/modules/react/src/components/export-video/export-video-panel-container.js
+++ b/modules/react/src/components/export-video/export-video-panel-container.js
@@ -140,11 +140,11 @@ export class ExportVideoPanelContainer extends Component {
     });
   }
 
-  getDeckScene(animationLoop) {
+  getDeckScene(timeline) {
     const {width, height} = this.getCanvasSize();
 
     return new DeckScene({
-      animationLoop,
+      timeline,
       width,
       height
     });

--- a/modules/react/src/components/quick-animation.js
+++ b/modules/react/src/components/quick-animation.js
@@ -23,9 +23,9 @@ export const QuickAnimation = ({
 
   const [viewState, setViewState] = useState(initialViewState);
 
-  const getDeckScene = animationLoop => {
+  const getDeckScene = timeline => {
     return new DeckScene({
-      animationLoop,
+      timeline,
       width,
       height,
       initialKeyframes: getLayerKeyframes()


### PR DESCRIPTION
Hubble only uses features of the Timeline object. Eventually it would be great if Hubble could supply a timeline to deck instead of the other way around, since we can then remove the `sceneBuilder` callback.