### PR TITLE
[chore] remove data param from DeckScene

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ import {easing} from 'popmotion';
 
 function getLayers(scene) {
   return [
-    new LineLayer({id: 'line-layer', data: scene.data})
+    new LineLayer({id: 'line-layer', data: [{sourcePosition: [-122.41669, 37.7853], targetPosition: [-122.41669, 37.781]}]})
   ]
 }
 
@@ -54,8 +54,7 @@ export function getCameraKeyframes() {
 }
 
 export function getDeckScene(timeline) {
-  const data = [{sourcePosition: [-122.41669, 37.7853], targetPosition: [-122.41669, 37.781]}];
-  return new DeckScene({timeline, data, width: 1920, height: 1080});
+  return new DeckScene({timeline, width: 1920, height: 1080});
 }
 ```
 

--- a/modules/core/docs/deck-adapter.md
+++ b/modules/core/docs/deck-adapter.md
@@ -15,11 +15,9 @@ Function to build scene, async or sync. See [DeckScene](/modules/core/docs/scene
 ```js
 async function sceneBuilder(timeline) {
   // See DeckScene API Reference for more info
-  const data = await fetch(...)
-  const lengthMs = 5000 // ms
   const width = 1920 // px
   const height = 1080 // px
-  return new DeckScene({timeline, data, lengthMs, width, height})
+  return new DeckScene({timeline, width, height})
 }
 ```
 

--- a/modules/core/docs/scene/deck-scene.md
+++ b/modules/core/docs/scene/deck-scene.md
@@ -14,21 +14,15 @@ const keyframes = {
 timeline.attachAnimation(keyframes.camera);
 
 // Optional unless animating deck.gl layer properties.
-const data = {
-  line: [{sourcePosition: [-122.41669, 37.7853], targetPosition: [-122.41669, 37.781]}],
-  arc: [{sourcePosition: [-122.41669, 37.7853], targetPosition: [-122.41669, 37.781]}]
-}
-// Optional unless animating deck.gl layer properties.
 const getLayers = (scene) => {
   return [
-    new LineLayer({ id: 'line-layer', data: scene.data.line }),
-    new ArcLayer({ id: 'arc-layer', data: scene.data.arc })
+    new LineLayer({ id: 'line-layer', data: [{sourcePosition: [-122.41669, 37.7853], targetPosition: [-122.41669, 37.781]}] }),
+    new ArcLayer({ id: 'arc-layer', data: [{sourcePosition: [-122.41669, 37.7853], targetPosition: [-122.41669, 37.781]}] })
   ]
 }
 
 const scene = new DeckScene({
   timeline,  
-  data,          // optional
   width,         // optional
   height         // optional
 });
@@ -37,7 +31,7 @@ const scene = new DeckScene({
 ## Constructor
 
 ```js
-new DeckScene({timeline, keyframes, data});
+new DeckScene({timeline, initialKeyframes});
 ```
 
 Parameters:
@@ -46,11 +40,9 @@ Parameters:
 
 A lumagl `timeline` object.
 
-##### `data` (Object, Optional)
+##### `initialKeyframes` (Object<string, Keyframes>)
 
-An object of data used to render layers.
-
-If set, the object is accessible in `getLayers` function via `scene.data`.
+An initial set of keyframes. If they are static, supply them here. If the ever need to update, call `scene.setKeyframes`.
 
 ## Methods
 

--- a/modules/core/src/scene/deck-scene.js
+++ b/modules/core/src/scene/deck-scene.js
@@ -21,8 +21,7 @@ import {Timeline} from '@luma.gl/engine';
 
 export default class DeckScene {
   /** @param {import('types').DeckSceneParams} params */
-  constructor({timeline, data, width, height, initialKeyframes = undefined}) {
-    this.data = data;
+  constructor({timeline, width, height, initialKeyframes = undefined}) {
     this.width = width;
     this.height = height;
 

--- a/modules/core/src/scene/kepler-scene.js
+++ b/modules/core/src/scene/kepler-scene.js
@@ -19,10 +19,9 @@
 // THE SOFTWARE.
 export default class KeplerScene {
   /** @param {import('types').KeplerSceneParams} params */
-  constructor({timeline, keyframes, data, filters, getFrame, lengthMs, width, height}) {
+  constructor({timeline, keyframes, filters, getFrame, lengthMs, width, height}) {
     this.timeline = timeline;
     this.keyframes = keyframes;
-    this.data = data;
     this._getFrame = getFrame;
     this.filters = filters;
     this.getFrame = this.getFrame.bind(this);

--- a/modules/core/src/types.d.ts
+++ b/modules/core/src/types.d.ts
@@ -47,10 +47,8 @@ interface FormatConfigs {
 
 interface DeckSceneParams {
   timeline: any
-  lengthMs: number
   width: number
   height: number
-  data: any
   initialKeyframes: Object<string, Keyframes>
 }
 
@@ -60,7 +58,6 @@ interface KeplerSceneParams {
   width: number
   height: number
   keyframes: any[]
-  data: any
   filters: any[]
   getFrame: (keplerGl: any, keyframes: any[], filters: any[]) => any
 }


### PR DESCRIPTION
Asynchronous data loading shouldn't be a concern of the Hubble library. This data prop was in conflict of that. Users should use deck.gl's asynchronous data loading features instead.