### PR TITLE
[refactor] Make scene definition synchronous by supplying our own Timeline

### DIFF
--- a/docs/api-reference/deck-adapter.md
+++ b/docs/api-reference/deck-adapter.md
@@ -3,35 +3,26 @@
 ## Constructor
 
 ```js
-new DeckAdapter(sceneBuilder);
+new DeckAdapter(scene);
 ```
 
 ## Parameters
 
-##### `sceneBuilder` (`(timeline) => Promise<DeckScene> | DeckScene`)
+##### `scene` (`DeckScene`)
 
-Function to build scene, async or sync. See [DeckScene](/docs/api-reference/scene/deck-scene) for more information.
-
-```js
-async function sceneBuilder(timeline) {
-  // See DeckScene API Reference for more info
-  const width = 1920 // px
-  const height = 1080 // px
-  return new DeckScene({timeline, width, height})
-}
-```
+See [DeckScene](/docs/api-reference/scene/deck-scene) for more information.
 
 ## Methods
 
-##### `getProps({deckRef, setReady, onNextFrame, getLayers, extraProps}): props`
+##### `getProps({deck, setReady, onNextFrame, getLayers, extraProps}): props`
 
 Supplies deck.gl properties from hubble.gl.
 
 Parameters:
 
-* `deckRef` (`React.RefObject`) - React ref eventually containing a `deck` object.
+* `deck` (`Deck`) - `deck` object from deck.gl.
 
-* `setReady` (`(ready: boolean) => void`, Optional) - Callback indicating webgl, scene, and deck are loaded. Scene is ready for rendering.
+* `setReady` (`(ready: boolean) => void`, Optional) - Callback indicating deck is loaded. Scene is ready for rendering.
 
 * `onNextFrame` (`(nextTimeMs: number) => void`, Optional) - Callback indicating the next frame in a rendering should be displayed.
 

--- a/docs/api-reference/scene/deck-scene.md
+++ b/docs/api-reference/scene/deck-scene.md
@@ -22,7 +22,7 @@ const getLayers = (scene) => {
 }
 
 const scene = new DeckScene({
-  timeline,  
+  initialKeyframes: keyframes, // optional
   width,         // optional
   height         // optional
 });
@@ -31,16 +31,16 @@ const scene = new DeckScene({
 ## Constructor
 
 ```js
-new DeckScene({timeline, initialKeyframes});
+new DeckScene({});
 ```
 
 Parameters:
 
-##### `timeline` (Object)
+##### `timeline` (`Object`, Optional)
 
-A lumagl `timeline` object.
+Override the lumagl `timeline` object used in scene.
 
-##### `initialKeyframes` (Object<string, Keyframes>)
+##### `initialKeyframes` (`Object<string, Keyframes>`, Optional)
 
 An initial set of keyframes. If they are static, supply them here. If the ever need to update, call `scene.setKeyframes`.
 

--- a/examples/camera/app.js
+++ b/examples/camera/app.js
@@ -1,4 +1,4 @@
-import React, {useState, useRef, useCallback} from 'react';
+import React, {useState, useRef, useCallback, useMemo} from 'react';
 import DeckGL from '@deck.gl/react';
 import {DeckAdapter, DeckScene, CameraKeyframes} from '@hubble.gl/core';
 import {useNextFrame, BasicControls, ResolutionGuide} from '@hubble.gl/react';
@@ -51,6 +51,7 @@ function filterCamera(viewState) {
 
 export default function App() {
   const deckRef = useRef(null);
+  const deck = useMemo(() => deckRef.current && deckRef.current.deck, [deckRef.current]);
   const [ready, setReady] = useState(false);
   const [busy, setBusy] = useState(false);
   const [viewState, setViewState] = useState(INITIAL_VIEW_STATE);
@@ -71,16 +72,15 @@ export default function App() {
     });
   }, [viewStateA, viewStateB]);
 
-  const getDeckScene = timeline => {
-    return new DeckScene({
-      timeline,
-      width: 640,
-      height: 480,
-      initialKeyframes: getKeyframes()
-    });
-  };
-
-  const [adapter] = useState(new DeckAdapter(getDeckScene));
+  const [adapter] = useState(
+    new DeckAdapter(
+      new DeckScene({
+        width: 640,
+        height: 480,
+        initialKeyframes: getKeyframes()
+      })
+    )
+  );
 
   return (
     <div style={{position: 'relative'}}>
@@ -103,7 +103,7 @@ export default function App() {
         }}
         controller={true}
         effects={[vignetteEffect, aaEffect]}
-        {...adapter.getProps({deckRef, setReady, onNextFrame, getLayers})}
+        {...adapter.getProps({deck, setReady, onNextFrame, getLayers})}
       />
       <div style={{position: 'absolute'}}>
         {ready && (

--- a/examples/camera/app.js
+++ b/examples/camera/app.js
@@ -52,7 +52,6 @@ function filterCamera(viewState) {
 export default function App() {
   const deckRef = useRef(null);
   const deck = useMemo(() => deckRef.current && deckRef.current.deck, [deckRef.current]);
-  const [ready, setReady] = useState(false);
   const [busy, setBusy] = useState(false);
   const [viewState, setViewState] = useState(INITIAL_VIEW_STATE);
   const [viewStateA, setViewStateA] = useState(viewState);
@@ -103,20 +102,18 @@ export default function App() {
         }}
         controller={true}
         effects={[vignetteEffect, aaEffect]}
-        {...adapter.getProps({deck, setReady, onNextFrame, getLayers})}
+        {...adapter.getProps({deck, onNextFrame, getLayers})}
       />
       <div style={{position: 'absolute'}}>
-        {ready && (
-          <BasicControls
-            adapter={adapter}
-            busy={busy}
-            setBusy={setBusy}
-            formatConfigs={formatConfigs}
-            timecode={timecode}
-            getCameraKeyframes={getCameraKeyframes}
-            getKeyframes={getKeyframes}
-          />
-        )}
+        <BasicControls
+          adapter={adapter}
+          busy={busy}
+          setBusy={setBusy}
+          formatConfigs={formatConfigs}
+          timecode={timecode}
+          getCameraKeyframes={getCameraKeyframes}
+          getKeyframes={getKeyframes}
+        />
         <button onClick={() => setViewStateA(filterCamera(viewState))}>Set Camera Start</button>
         <button onClick={() => setViewStateB(filterCamera(viewState))}>Set Camera End</button>
       </div>

--- a/examples/kepler-integration/src/main.js
+++ b/examples/kepler-integration/src/main.js
@@ -27,7 +27,9 @@ import App from './app';
 
 const Root = () => (
   <Provider store={store}>
-    <App />
+    <div style={{height: '100vh', width: '100vw'}}>
+      <App />
+    </div>
   </Provider>
 );
 

--- a/examples/terrain/app.js
+++ b/examples/terrain/app.js
@@ -1,4 +1,4 @@
-import React, {useState, useRef} from 'react';
+import React, {useState, useRef, useMemo} from 'react';
 import DeckGL from '@deck.gl/react';
 import {TerrainLayer} from '@deck.gl/geo-layers';
 import {useNextFrame, BasicControls, ResolutionGuide} from '@hubble.gl/react';
@@ -122,6 +122,7 @@ const timecode = {
 
 export default function App() {
   const deckRef = useRef(null);
+  const deck = useMemo(() => deckRef.current && deckRef.current.deck, [deckRef.current]);
   const [ready, setReady] = useState(false);
   const [busy, setBusy] = useState(false);
   const [viewState, setViewState] = useState(INITIAL_VIEW_STATE);
@@ -129,16 +130,15 @@ export default function App() {
   const onNextFrame = useNextFrame();
   const [rainbow, setRainbow] = useState(false);
 
-  const getDeckScene = timeline => {
-    return new DeckScene({
-      timeline,
-      width: 640,
-      height: 480,
-      initialKeyframes: getKeyframes()
-    });
-  };
-
-  const [adapter] = useState(new DeckAdapter(getDeckScene));
+  const [adapter] = useState(
+    new DeckAdapter(
+      new DeckScene({
+        width: 640,
+        height: 480,
+        initialKeyframes: getKeyframes()
+      })
+    )
+  );
 
   const getLayers = scene => {
     const terrain = scene.keyframes.terrain.getFrame();
@@ -170,7 +170,7 @@ export default function App() {
           setViewState(vs);
         }}
         controller={true}
-        {...adapter.getProps({deckRef, setReady, onNextFrame, getLayers})}
+        {...adapter.getProps({deck, setReady, onNextFrame, getLayers})}
       />
       <div style={{position: 'absolute'}}>
         {ready && (

--- a/examples/terrain/app.js
+++ b/examples/terrain/app.js
@@ -123,7 +123,6 @@ const timecode = {
 export default function App() {
   const deckRef = useRef(null);
   const deck = useMemo(() => deckRef.current && deckRef.current.deck, [deckRef.current]);
-  const [ready, setReady] = useState(false);
   const [busy, setBusy] = useState(false);
   const [viewState, setViewState] = useState(INITIAL_VIEW_STATE);
 
@@ -170,20 +169,18 @@ export default function App() {
           setViewState(vs);
         }}
         controller={true}
-        {...adapter.getProps({deck, setReady, onNextFrame, getLayers})}
+        {...adapter.getProps({deck, onNextFrame, getLayers})}
       />
       <div style={{position: 'absolute'}}>
-        {ready && (
-          <BasicControls
-            adapter={adapter}
-            busy={busy}
-            setBusy={setBusy}
-            formatConfigs={formatConfigs}
-            timecode={timecode}
-            getCameraKeyframes={getCameraKeyframes}
-            getKeyframes={getKeyframes}
-          />
-        )}
+        <BasicControls
+          adapter={adapter}
+          busy={busy}
+          setBusy={setBusy}
+          formatConfigs={formatConfigs}
+          timecode={timecode}
+          getCameraKeyframes={getCameraKeyframes}
+          getKeyframes={getKeyframes}
+        />
         <div style={{backgroundColor: 'rgba(255, 255, 255, 0.5)'}}>
           <label style={{fontFamily: 'sans-serif'}}>
             <input type="checkbox" checked={rainbow} onChange={() => setRainbow(!rainbow)} />

--- a/examples/trips/app.js
+++ b/examples/trips/app.js
@@ -110,7 +110,6 @@ export default function App({
   const deck = useMemo(() => deckRef.current && deckRef.current.deck, [deckRef.current]);
   const mapRef = useRef(null);
 
-  const [ready, setReady] = useState(false);
   const [busy, setBusy] = useState(false);
   const nextFrame = useNextFrame();
 
@@ -227,7 +226,7 @@ export default function App({
           // blendEquation: GL.FUNC_ADD,
           blendFunc: [GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA]
         }}
-        {...adapter.getProps({deck, setReady})}
+        {...adapter.getProps({deck})}
       >
         {glContext && (
           <StaticMap
@@ -242,16 +241,14 @@ export default function App({
       </DeckGL>
 
       <div style={{position: 'absolute'}}>
-        {ready && (
-          <BasicControls
-            adapter={adapter}
-            busy={busy}
-            setBusy={setBusy}
-            formatConfigs={formatConfigs}
-            timecode={timecode}
-            getCameraKeyframes={getCameraKeyframes}
-          />
-        )}
+        <BasicControls
+          adapter={adapter}
+          busy={busy}
+          setBusy={setBusy}
+          formatConfigs={formatConfigs}
+          timecode={timecode}
+          getCameraKeyframes={getCameraKeyframes}
+        />
       </div>
     </div>
   );

--- a/examples/trips/app.js
+++ b/examples/trips/app.js
@@ -135,7 +135,7 @@ export default function App({
     map.addLayer(new MapboxLayer({id: 'buildings', deck}));
     map.addLayer(new MapboxLayer({id: 'ground', deck}));
 
-    map.on('render', () => adapter.onAfterRender(deck, nextFrame));
+    map.on('render', () => adapter.onAfterRender(nextFrame));
   }, []);
 
   const animate = () => {
@@ -227,7 +227,7 @@ export default function App({
           // blendEquation: GL.FUNC_ADD,
           blendFunc: [GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA]
         }}
-        {...adapter.getProps({setReady})}
+        {...adapter.getProps({deck, setReady})}
       >
         {glContext && (
           <StaticMap

--- a/examples/worldview/src/features/map/Map.js
+++ b/examples/worldview/src/features/map/Map.js
@@ -107,7 +107,7 @@ export class Map extends Component {
     }
 
     map.on('render', () =>
-      adapter.onAfterRender(() => {
+      adapter.onAfterRender(deck, () => {
         prepareFrame(adapter.scene);
         this.forceUpdate();
       })
@@ -140,7 +140,7 @@ export class Map extends Component {
           onWebGLInitialized={gl => this.setState({glContext: gl})}
           onViewStateChange={({viewState: vs}) => setViewState(vs)}
           // onClick={visStateActions.onLayerClick}
-          {...adapter.getProps({deckRef: this.deckRef, setReady: () => {}, extraProps: deckProps})}
+          {...adapter.getProps({setReady: () => {}, extraProps: deckProps})}
         >
           {this.state.glContext && (
             <StaticMap

--- a/examples/worldview/src/features/map/Map.js
+++ b/examples/worldview/src/features/map/Map.js
@@ -107,7 +107,7 @@ export class Map extends Component {
     }
 
     map.on('render', () =>
-      adapter.onAfterRender(deck, () => {
+      adapter.onAfterRender(() => {
         prepareFrame(adapter.scene);
         this.forceUpdate();
       })
@@ -116,6 +116,7 @@ export class Map extends Component {
 
   render() {
     const {adapter, viewState, width, height, setViewState, deckProps, staticMapProps} = this.props;
+    const deck = this.deckRef.current && this.deckRef.current.deck;
 
     const deckStyle = {
       width: '100%',
@@ -140,7 +141,7 @@ export class Map extends Component {
           onWebGLInitialized={gl => this.setState({glContext: gl})}
           onViewStateChange={({viewState: vs}) => setViewState(vs)}
           // onClick={visStateActions.onLayerClick}
-          {...adapter.getProps({setReady: () => {}, extraProps: deckProps})}
+          {...adapter.getProps({deck, setReady: () => {}, extraProps: deckProps})}
         >
           {this.state.glContext && (
             <StaticMap

--- a/examples/worldview/src/features/map/Map.js
+++ b/examples/worldview/src/features/map/Map.js
@@ -141,7 +141,7 @@ export class Map extends Component {
           onWebGLInitialized={gl => this.setState({glContext: gl})}
           onViewStateChange={({viewState: vs}) => setViewState(vs)}
           // onClick={visStateActions.onLayerClick}
-          {...adapter.getProps({deck, setReady: () => {}, extraProps: deckProps})}
+          {...adapter.getProps({deck, extraProps: deckProps})}
         >
           {this.state.glContext && (
             <StaticMap

--- a/examples/worldview/src/features/map/MapContainer.js
+++ b/examples/worldview/src/features/map/MapContainer.js
@@ -18,13 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {useMemo, useCallback, useEffect} from 'react';
+import React, {useMemo, useEffect} from 'react';
 import {DeckAdapter, DeckScene} from '@hubble.gl/core';
 
 import {Map} from './Map';
 import {useDispatch, useSelector} from 'react-redux';
 
-import {setupRenderer, dimensionSelector, durationSelector} from '../renderer';
+import {setupRenderer, dimensionSelector} from '../renderer';
 
 import {updateViewState, viewStateSelector} from './mapSlice';
 
@@ -39,24 +39,18 @@ export const MapContainer = ({
   const dispatch = useDispatch();
   const dimension = useSelector(dimensionSelector);
   const viewState = useSelector(viewStateSelector);
-  const duration = useSelector(durationSelector);
 
-  const getDeckScene = useCallback(
-    timeline => {
-      return new DeckScene({
-        timeline,
-        lengthMs: duration,
-        width: dimension.width,
-        height: dimension.height
-      });
-    },
-    [duration, dimension]
+  const adapter = useMemo(
+    () =>
+      new DeckAdapter(
+        new DeckScene({
+          width: dimension.width,
+          height: dimension.height
+        }),
+        glContext
+      ),
+    [glContext, dimension]
   );
-
-  const adapter = useMemo(() => new DeckAdapter(getDeckScene, glContext), [
-    getDeckScene,
-    glContext
-  ]);
 
   useEffect(() => {
     dispatch(setupRenderer(adapter));

--- a/modules/core/src/adapters/deck-adapter.js
+++ b/modules/core/src/adapters/deck-adapter.js
@@ -47,7 +47,6 @@ export default class DeckAdapter {
     this.render = this.render.bind(this);
     this.stop = this.stop.bind(this);
     this.seek = this.seek.bind(this);
-    this._getLayers = this._getLayers.bind(this);
   }
 
   /**
@@ -87,7 +86,7 @@ export default class DeckAdapter {
     // Construct layers using callback.
     // TODO: Could potentially concat instead of replace, but layers are supposed to be static.
     if (getLayers) {
-      props.layers = this._getLayers(getLayers);
+      props.layers = getLayers(this.scene);
     }
 
     props.width = this.scene.width;
@@ -161,10 +160,6 @@ export default class DeckAdapter {
       this.scene.setKeyframes(getKeyframes());
     }
     this.scene.timeline.setTime(timeMs);
-  }
-
-  _getLayers(getLayers) {
-    return getLayers(this.scene);
   }
 
   /**

--- a/modules/core/src/adapters/deck-adapter.js
+++ b/modules/core/src/adapters/deck-adapter.js
@@ -47,7 +47,6 @@ export default class DeckAdapter {
     this.render = this.render.bind(this);
     this.stop = this.stop.bind(this);
     this.seek = this.seek.bind(this);
-    this._getViewState = this._getViewState.bind(this);
     this._getLayers = this._getLayers.bind(this);
   }
 
@@ -80,9 +79,9 @@ export default class DeckAdapter {
     }
 
     // Animating the camera is optional, but if a keyframe is defined then viewState is controlled by camera keyframe.
-    if (this.scene && this.scene.keyframes.camera && this.enabled) {
+    if (this.scene.keyframes.camera && this.enabled) {
       props.controller = false;
-      props.viewState = this._getViewState();
+      props.viewState = this.scene.keyframes.camera.getFrame();
     }
 
     // Construct layers using callback.
@@ -91,11 +90,9 @@ export default class DeckAdapter {
       props.layers = this._getLayers(getLayers);
     }
 
-    if (this.scene) {
-      props.width = this.scene.width;
-      props.height = this.scene.height;
-      props._timeline = this.scene.timeline;
-    }
+    props.width = this.scene.width;
+    props.height = this.scene.height;
+    props._timeline = this.scene.timeline;
 
     if (this.glContext) {
       props.gl = this.glContext;
@@ -157,29 +154,16 @@ export default class DeckAdapter {
    * @param {() => Object<string, import('../keyframes').Keyframes>} params.getKeyframes
    */
   seek({timeMs, getCameraKeyframes = undefined, getKeyframes = undefined}) {
-    if (this.scene) {
-      if (getCameraKeyframes) {
-        this.scene.setCameraKeyframes(getCameraKeyframes());
-      }
-      if (getKeyframes) {
-        this.scene.setKeyframes(getKeyframes());
-      }
-      this.scene.timeline.setTime(timeMs);
+    if (getCameraKeyframes) {
+      this.scene.setCameraKeyframes(getCameraKeyframes());
     }
-  }
-
-  _getViewState() {
-    if (!this.scene) {
-      return null;
+    if (getKeyframes) {
+      this.scene.setKeyframes(getKeyframes());
     }
-    const frame = this.scene.keyframes.camera.getFrame();
-    return frame;
+    this.scene.timeline.setTime(timeMs);
   }
 
   _getLayers(getLayers) {
-    if (!this.scene) {
-      return [];
-    }
     return getLayers(this.scene);
   }
 

--- a/modules/core/src/adapters/deck-adapter.js
+++ b/modules/core/src/adapters/deck-adapter.js
@@ -68,11 +68,7 @@ export default class DeckAdapter {
   }) {
     this.deck = deck;
     const props = {
-      onLoad: () => {
-        this.scene.timeline.pause();
-        this.scene.timeline.setTime(0);
-        setReady(true);
-      },
+      onLoad: () => setReady(true),
       _animate: this.shouldAnimate
     };
 

--- a/modules/core/src/adapters/deck-adapter.js
+++ b/modules/core/src/adapters/deck-adapter.js
@@ -23,6 +23,8 @@ import {PreviewEncoder} from '../encoders';
 import {DeckScene} from '../scene';
 import {VideoCapture} from '../capture/video-capture';
 
+function noop() {}
+
 export default class DeckAdapter {
   /** @type {any} */
   deck;
@@ -61,7 +63,7 @@ export default class DeckAdapter {
    */
   getProps({
     deck,
-    setReady,
+    setReady = noop,
     onNextFrame = undefined,
     getLayers = undefined,
     extraProps = undefined
@@ -165,9 +167,11 @@ export default class DeckAdapter {
    * @param {(nextTimeMs: number) => void} proceedToNextFrame
    */
   onAfterRender(proceedToNextFrame) {
-    this.videoCapture.capture(this.deck.canvas, nextTimeMs => {
-      this.scene.timeline.setTime(nextTimeMs);
-      proceedToNextFrame(nextTimeMs);
-    });
+    if (this.videoCapture.isRecording()) {
+      this.videoCapture.capture(this.deck.canvas, nextTimeMs => {
+        this.scene.timeline.setTime(nextTimeMs);
+        proceedToNextFrame(nextTimeMs);
+      });
+    }
   }
 }

--- a/modules/core/src/adapters/deck-adapter.js
+++ b/modules/core/src/adapters/deck-adapter.js
@@ -90,7 +90,7 @@ export default class DeckAdapter {
 
     props.width = this.scene.width;
     props.height = this.scene.height;
-    props._timeline = this.scene.timeline;
+    // props._timeline = this.scene.timeline; TODO: uncomment when shipped in deck.
 
     if (this.glContext) {
       props.gl = this.glContext;

--- a/modules/core/src/adapters/deck-adapter.js
+++ b/modules/core/src/adapters/deck-adapter.js
@@ -24,6 +24,8 @@ import {DeckScene} from '../scene';
 import {VideoCapture} from '../capture/video-capture';
 
 export default class DeckAdapter {
+  /** @type {any} */
+  deck;
   /** @type {DeckScene} */
   scene;
   /** @type {boolean} */
@@ -64,6 +66,7 @@ export default class DeckAdapter {
     getLayers = undefined,
     extraProps = undefined
   }) {
+    this.deck = deck;
     const props = {
       onLoad: () => {
         this.scene.timeline.pause();
@@ -73,8 +76,8 @@ export default class DeckAdapter {
       _animate: this.shouldAnimate
     };
 
-    if (deck && onNextFrame) {
-      props.onAfterRender = () => this.onAfterRender(deck, onNextFrame);
+    if (onNextFrame) {
+      props.onAfterRender = () => this.onAfterRender(onNextFrame);
     }
 
     // Animating the camera is optional, but if a keyframe is defined then viewState is controlled by camera keyframe.
@@ -165,8 +168,8 @@ export default class DeckAdapter {
   /**
    * @param {(nextTimeMs: number) => void} proceedToNextFrame
    */
-  onAfterRender(deck, proceedToNextFrame) {
-    this.videoCapture.capture(deck.canvas, nextTimeMs => {
+  onAfterRender(proceedToNextFrame) {
+    this.videoCapture.capture(this.deck.canvas, nextTimeMs => {
       this.scene.timeline.setTime(nextTimeMs);
       proceedToNextFrame(nextTimeMs);
     });

--- a/modules/react/src/components/export-video/export-video-panel-container.js
+++ b/modules/react/src/components/export-video/export-video-panel-container.js
@@ -52,7 +52,6 @@ export class ExportVideoPanelContainer extends Component {
     this.setResolution = this.setResolution.bind(this);
     this.setViewState = this.setViewState.bind(this);
     this.getCameraKeyframes = this.getCameraKeyframes.bind(this);
-    this.getDeckScene = this.getDeckScene.bind(this);
     this.onPreviewVideo = this.onPreviewVideo.bind(this);
     this.onRenderVideo = this.onRenderVideo.bind(this);
     this.setDuration = this.setDuration.bind(this);
@@ -71,10 +70,12 @@ export class ExportVideoPanelContainer extends Component {
       resolution: '1280x720',
       durationMs: 1000,
       viewState: mapState,
-      adapter: new DeckAdapter(this.getDeckScene, glContext),
       rendering: false, // Will set a spinner overlay if true
       ...(initialState || {})
     };
+    const {width, height} = this.getCanvasSize();
+    const scene = new DeckScene({width, height});
+    this.state.adapter = new DeckAdapter(scene, glContext);
   }
 
   getFileName() {
@@ -137,16 +138,6 @@ export class ExportVideoPanelContainer extends Component {
         parseSetCameraType(cameraPreset, viewState)
       ],
       easings: [easing.easeInOut]
-    });
-  }
-
-  getDeckScene(timeline) {
-    const {width, height} = this.getCanvasSize();
-
-    return new DeckScene({
-      timeline,
-      width,
-      height
     });
   }
 

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -50,7 +50,6 @@ export class ExportVideoPanelPreview extends Component {
     this._onMapLoad = this._onMapLoad.bind(this);
     this._resizeVideo = this._resizeVideo.bind(this);
     this._getContainerHeight = this._getContainerHeight.bind(this);
-
     this._resizeVideo();
   }
 
@@ -163,8 +162,6 @@ export class ExportVideoPanelPreview extends Component {
 
     const keplerLayers = this.createLayers();
 
-    map.addLayer(new MapboxLayer({id: 'my-deck', deck}));
-
     for (let i = 0; i < keplerLayers.length; i++) {
       // Adds DeckGL layers to Mapbox so Mapbox can be the bottom layer. Removing this clips DeckGL layers
       map.addLayer(new MapboxLayer({id: keplerLayers[i].id, deck}));
@@ -201,7 +198,7 @@ export class ExportVideoPanelPreview extends Component {
             onWebGLInitialized={gl => this.setState({glContext: gl})}
             onViewStateChange={setViewState}
             // onClick={visStateActions.onLayerClick}
-            {...adapter.getProps({deckRef: this.deckRef, setReady: () => {}})}
+            {...adapter.getProps({setReady: () => {}})}
           >
             {glContext && (
               <StaticMap

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -168,7 +168,7 @@ export class ExportVideoPanelPreview extends Component {
     }
 
     map.on('render', () =>
-      this.props.adapter.onAfterRender(deck, () => {
+      this.props.adapter.onAfterRender(() => {
         this.forceUpdate();
       })
     );
@@ -177,7 +177,7 @@ export class ExportVideoPanelPreview extends Component {
   render() {
     const {exportVideoWidth, rendering, viewState, setViewState, adapter, durationMs} = this.props;
     const {glContext, mapStyle} = this.state;
-
+    const deck = this.deckRef.current && this.deckRef.current.deck;
     const containerStyle = {
       width: `${exportVideoWidth}px`,
       height: `${this._getContainerHeight()}px`,
@@ -198,7 +198,7 @@ export class ExportVideoPanelPreview extends Component {
             onWebGLInitialized={gl => this.setState({glContext: gl})}
             onViewStateChange={setViewState}
             // onClick={visStateActions.onLayerClick}
-            {...adapter.getProps({setReady: () => {}})}
+            {...adapter.getProps({deck, setReady: () => {}})}
           >
             {glContext && (
               <StaticMap

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -168,7 +168,7 @@ export class ExportVideoPanelPreview extends Component {
     }
 
     map.on('render', () =>
-      this.props.adapter.onAfterRender(() => {
+      this.props.adapter.onAfterRender(deck, () => {
         this.forceUpdate();
       })
     );

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -198,7 +198,7 @@ export class ExportVideoPanelPreview extends Component {
             onWebGLInitialized={gl => this.setState({glContext: gl})}
             onViewStateChange={setViewState}
             // onClick={visStateActions.onLayerClick}
-            {...adapter.getProps({deck, setReady: () => {}})}
+            {...adapter.getProps({deck})}
           >
             {glContext && (
               <StaticMap

--- a/modules/react/src/components/quick-animation.js
+++ b/modules/react/src/components/quick-animation.js
@@ -1,4 +1,4 @@
-import React, {useState, useRef} from 'react';
+import React, {useState, useRef, useMemo} from 'react';
 import DeckGL from '@deck.gl/react';
 import {DeckScene, DeckAdapter} from '@hubble.gl/core';
 import ResolutionGuide from './resolution-guide';
@@ -17,22 +17,22 @@ export const QuickAnimation = ({
   deckProps = {}
 }) => {
   const deckRef = useRef(null);
+  const deck = useMemo(() => deckRef.current && deckRef.current.deck, [deckRef.current]);
   const [ready, setReady] = useState(false);
   const [busy, setBusy] = useState(false);
   const onNextFrame = useNextFrame();
 
   const [viewState, setViewState] = useState(initialViewState);
 
-  const getDeckScene = timeline => {
-    return new DeckScene({
-      timeline,
-      width,
-      height,
-      initialKeyframes: getLayerKeyframes()
-    });
-  };
-
-  const [adapter] = useState(new DeckAdapter(getDeckScene));
+  const [adapter] = useState(
+    new DeckAdapter(
+      new DeckScene({
+        width,
+        height,
+        initialKeyframes: getLayerKeyframes()
+      })
+    )
+  );
 
   const mergedFormatConfigs = {
     webm: {
@@ -67,8 +67,7 @@ export const QuickAnimation = ({
           setViewState(vs);
         }}
         controller={true}
-        {...adapter.getProps({deckRef, setReady, onNextFrame, getLayers})}
-        {...deckProps}
+        {...adapter.getProps({deck, setReady, onNextFrame, getLayers, extraProps: deckProps})}
       />
       <div style={{position: 'absolute'}}>
         {ready && (

--- a/modules/react/src/components/quick-animation.js
+++ b/modules/react/src/components/quick-animation.js
@@ -18,20 +18,21 @@ export const QuickAnimation = ({
 }) => {
   const deckRef = useRef(null);
   const deck = useMemo(() => deckRef.current && deckRef.current.deck, [deckRef.current]);
-  const [ready, setReady] = useState(false);
   const [busy, setBusy] = useState(false);
   const onNextFrame = useNextFrame();
 
   const [viewState, setViewState] = useState(initialViewState);
 
-  const [adapter] = useState(
-    new DeckAdapter(
-      new DeckScene({
-        width,
-        height,
-        initialKeyframes: getLayerKeyframes()
-      })
-    )
+  const adapter = useMemo(
+    () =>
+      new DeckAdapter(
+        new DeckScene({
+          width,
+          height,
+          initialKeyframes: getLayerKeyframes()
+        })
+      ),
+    [width, height]
   );
 
   const mergedFormatConfigs = {
@@ -67,22 +68,20 @@ export const QuickAnimation = ({
           setViewState(vs);
         }}
         controller={true}
-        {...adapter.getProps({deck, setReady, onNextFrame, getLayers, extraProps: deckProps})}
+        {...adapter.getProps({deck, onNextFrame, getLayers, extraProps: deckProps})}
       />
       <div style={{position: 'absolute'}}>
-        {ready && (
-          <BasicControls
-            adapter={adapter}
-            busy={busy}
-            setBusy={setBusy}
-            formatConfigs={mergedFormatConfigs}
-            timecode={mergedTimecode}
-            getCameraKeyframes={
-              getCameraKeyframes ? () => getCameraKeyframes(viewState) : getCameraKeyframes
-            }
-            getKeyframes={getLayerKeyframes}
-          />
-        )}
+        <BasicControls
+          adapter={adapter}
+          busy={busy}
+          setBusy={setBusy}
+          formatConfigs={mergedFormatConfigs}
+          timecode={mergedTimecode}
+          getCameraKeyframes={
+            getCameraKeyframes ? () => getCameraKeyframes(viewState) : getCameraKeyframes
+          }
+          getKeyframes={getLayerKeyframes}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
- async `new DeckAdapter({sceneBuilder})` removed, replaced by synchronous `scene` object parameter.
- `DeckAdapter.render({setReady})` is now optional since deck will only be referenced when recording.
- Removed complexity inside `DeckAdapter` implementation.
- Docs