### PR TITLE
[chore] remove unnecessary readiness checks

### DIFF
--- a/docs/api-reference/deck-adapter.md
+++ b/docs/api-reference/deck-adapter.md
@@ -14,15 +14,13 @@ See [DeckScene](/docs/api-reference/scene/deck-scene) for more information.
 
 ## Methods
 
-##### `getProps({deck, setReady, onNextFrame, getLayers, extraProps}): props`
+##### `getProps({deck, onNextFrame, getLayers, extraProps}): props`
 
 Supplies deck.gl properties from hubble.gl.
 
 Parameters:
 
 * `deck` (`Deck`) - `deck` object from deck.gl.
-
-* `setReady` (`(ready: boolean) => void`, Optional) - Callback indicating deck is loaded. Scene is ready for rendering.
 
 * `onNextFrame` (`(nextTimeMs: number) => void`, Optional) - Callback indicating the next frame in a rendering should be displayed.
 

--- a/examples/worldview/src/app/App.js
+++ b/examples/worldview/src/app/App.js
@@ -86,7 +86,6 @@ const selectKeplerLayers = createSelectKeplerLayers(KEPLER_MAP_ID);
 const selectMapStyle = createSelectMapStyle(KEPLER_MAP_ID);
 const sceneLayers = [];
 const App = ({}) => {
-  const ready = useSelector(state => state.hubbleGl.map.ready);
   useKepler(KEPLER_MAP_ID);
   const keplerLayers = useSelector(selectKeplerLayers);
   const getKeyframes = useKeplerKeyframes(keplerLayers);
@@ -113,17 +112,13 @@ const App = ({}) => {
         <GlobalStyle>
           <WindowSize>
             <InjectKeplerUI keplerUI={KEPLER_UI}>
-              {ready && (
-                <>
-                  <div style={{height: 1080, margin: 16}}>
-                    <MonitorPanel
-                      getKeyframes={getKeyframes}
-                      deckProps={deckProps}
-                      staticMapProps={staticMapProps}
-                    />
-                  </div>
-                </>
-              )}
+              <div style={{height: 1080, margin: 16}}>
+                <MonitorPanel
+                  getKeyframes={getKeyframes}
+                  deckProps={deckProps}
+                  staticMapProps={staticMapProps}
+                />
+              </div>
             </InjectKeplerUI>
           </WindowSize>
         </GlobalStyle>

--- a/examples/worldview/src/app/appSlice.js
+++ b/examples/worldview/src/app/appSlice.js
@@ -17,40 +17,19 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+/* eslint-disable no-void */
+import {createSlice} from '@reduxjs/toolkit';
 
-import {handleActions} from 'redux-actions';
-
-export const SET_SAMPLE_LOADING_STATUS = 'SET_SAMPLE_LOADING_STATUS';
-
-export function setLoadingMapStatus(isMapLoading) {
-  return {
-    type: SET_SAMPLE_LOADING_STATUS,
-    isMapLoading
-  };
-}
-
-// INITIAL_APP_STATE
-const initialAppState = {
-  appName: 'example',
-  loaded: false,
-  isMapLoading: false, // determine whether we are loading a sample map,
-  error: null // contains error when loading/retrieving data/configuration
-  // {
-  //   status: null,
-  //   message: null
-  // }
-  // eventually we may have an async process to fetch these from a remote location
+const initialState = {
+  keplerRegistered: false
 };
 
-// App reducer
-const appReducer = handleActions(
-  {
-    [SET_SAMPLE_LOADING_STATUS]: (state, action) => ({
-      ...state,
-      isMapLoading: action.isMapLoading
-    })
-  },
-  initialAppState
-);
+const appSlice = createSlice({
+  name: 'app',
+  initialState,
+  extraReducers: builder => {
+    builder.addCase('@@kepler.gl/REGISTER_ENTRY', state => void (state.keplerRegistered = true));
+  }
+});
 
-export default appReducer;
+export default appSlice.reducer;

--- a/examples/worldview/src/app/hooks.js
+++ b/examples/worldview/src/app/hooks.js
@@ -1,0 +1,8 @@
+import {useEffect} from 'react';
+import {useSelector} from 'react-redux';
+export const useAfterKepler = onRegistered => {
+  const registered = useSelector(state => state.app.keplerRegistered);
+  useEffect(() => {
+    if (registered) onRegistered();
+  }, [registered]);
+};

--- a/examples/worldview/src/app/index.js
+++ b/examples/worldview/src/app/index.js
@@ -1,0 +1,2 @@
+export {default as appReducer} from './appSlice';
+export {useAfterKepler} from './hooks';

--- a/examples/worldview/src/features/map/hooks.js
+++ b/examples/worldview/src/features/map/hooks.js
@@ -1,8 +1,0 @@
-import {useEffect} from 'react';
-import {useSelector} from 'react-redux';
-export const useWhenReady = onReady => {
-  const ready = useSelector(state => state.hubbleGl.map.ready);
-  useEffect(() => {
-    if (ready) onReady();
-  }, [ready]);
-};

--- a/examples/worldview/src/features/map/index.js
+++ b/examples/worldview/src/features/map/index.js
@@ -1,3 +1,2 @@
 export {MapContainer as Map} from './MapContainer';
 export {default as mapReducer, updateViewState, viewStateSelector} from './mapSlice';
-export {useWhenReady} from './hooks';

--- a/examples/worldview/src/features/map/mapSlice.js
+++ b/examples/worldview/src/features/map/mapSlice.js
@@ -2,7 +2,6 @@
 import {createSlice} from '@reduxjs/toolkit';
 
 const initialState = {
-  ready: false,
   viewState: undefined
 };
 
@@ -12,9 +11,6 @@ const mapSlice = createSlice({
   reducers: {
     updateViewState: (state, action) =>
       void (state.viewState = {...state.viewState, ...action.payload})
-  },
-  extraReducers: builder => {
-    builder.addCase('@@kepler.gl/REGISTER_ENTRY', state => void (state.ready = true));
   }
 });
 

--- a/examples/worldview/src/scenes/newYork/index.js
+++ b/examples/worldview/src/scenes/newYork/index.js
@@ -1,5 +1,6 @@
 import {useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
+import {useAfterKepler} from '../../app';
 import {useKeplerMapState} from '../../features/kepler/hooks';
 import {loadSampleData} from './data';
 import {updateCameraKeyframes} from '../../features/timeline/timelineSlice';
@@ -10,7 +11,7 @@ import {
   formatConfigsChange,
   durationSelector
 } from '../../features/renderer';
-import {useWhenReady, viewStateSelector} from '../../features/map';
+import {viewStateSelector} from '../../features/map';
 import {easing} from 'popmotion';
 
 export const useNewYorkScene = () => {
@@ -53,6 +54,6 @@ export const useNewYorkScene = () => {
     }
   }, [viewState, duration]);
 
-  useWhenReady(newYorkScene);
+  useAfterKepler(newYorkScene);
   useKeplerMapState('map');
 };

--- a/examples/worldview/src/store.js
+++ b/examples/worldview/src/store.js
@@ -25,7 +25,7 @@ import {rendererMiddleware} from './features/renderer';
 // eslint-disable-next-line no-unused-vars
 import window from 'global/window';
 
-import appReducer from './app/appSlice';
+import {appReducer} from './app';
 import keplerGlReducer from './features/kepler/keplerSlice';
 
 import rendererReducer from './features/renderer/rendererSlice';

--- a/modules/core/src/adapters/deck-adapter.js
+++ b/modules/core/src/adapters/deck-adapter.js
@@ -23,8 +23,6 @@ import {PreviewEncoder} from '../encoders';
 import {DeckScene} from '../scene';
 import {VideoCapture} from '../capture/video-capture';
 
-function noop() {}
-
 export default class DeckAdapter {
   /** @type {any} */
   deck;
@@ -56,21 +54,13 @@ export default class DeckAdapter {
   /**
    * @param {Object} params
    * @param {any} params.deck
-   * @param {(ready: boolean) => void} params.setReady
    * @param {(nextTimeMs: number) => void} params.onNextFrame
    * @param {(scene: DeckScene) => any[]} params.getLayers
    * @param {Object} params.extraProps
    */
-  getProps({
-    deck,
-    setReady = noop,
-    onNextFrame = undefined,
-    getLayers = undefined,
-    extraProps = undefined
-  }) {
+  getProps({deck, onNextFrame = undefined, getLayers = undefined, extraProps = undefined}) {
     this.deck = deck;
     const props = {
-      onLoad: () => setReady(true),
       _animate: this.shouldAnimate
     };
 


### PR DESCRIPTION
- [chore] remove DeckAdapter.getProps({setReady})
- [refactor] worldview remove "wait for ready" from lib
- Users can now use `deck.onLoad` in their apps without hubble overriding it.