### PR TITLE
[chore] remove width and height from DeckScene

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ npm install hubble.gl
 
 ## Basic Scene
 
-To create an animation and render it you will need to first create a [deck.gl](https://deck.gl/docs/get-started/getting-started) project. Then create a `DeckAdapter` and `DeckScene`, a `timecode` object, and define some keyframes (e.g. `CameraKeyframes`)
+To create an animation and render it you will need to first create a [deck.gl](https://deck.gl/docs/get-started/getting-started) project. Then create a `DeckAdapter`, a `timecode` object, and define some keyframes (e.g. `CameraKeyframes`)
 
 Hubble.gl provide a `useNextFrame` hook for React.js to trigger a render when necessary, and provides the `<BasicControls/>` component for convenience to get your animation started.
 
@@ -25,7 +25,7 @@ import React, {useState, useRef, useMemo} from 'react';
 import DeckGL from '@deck.gl/react';
 import {useNextFrame, BasicControls} from '@hubble.gl/react';
 import {LineLayer} from '@deck.gl/layers';
-import {DeckScene, DeckAdapter, CameraKeyframes} from 'hubble.gl';
+import {DeckAdapter, CameraKeyframes} from 'hubble.gl';
 import {easing} from 'popmotion';
 
 const timecode = {
@@ -34,7 +34,12 @@ const timecode = {
   framerate: 30
 }
 
-const adapter = new DeckAdapter(new DeckScene({width: 1920, height: 1080}));
+const dimension = {
+  width: 1920,
+  height: 1080
+}
+
+const adapter = new DeckAdapter({});
 
 function getCameraKeyframes() {
   return new CameraKeyframes({
@@ -75,6 +80,8 @@ export default function App() {
     <div style={{position: 'relative'}}>
       <DeckGL
         ref={deckRef}
+        width={dimension.width}
+        height={dimension.height}
         {...adapter.getProps({deck, onNextFrame, getLayers})}
       />
       <div style={{position: 'absolute'}}>

--- a/docs/api-reference/deck-adapter.md
+++ b/docs/api-reference/deck-adapter.md
@@ -3,14 +3,16 @@
 ## Constructor
 
 ```js
-new DeckAdapter(scene);
+new DeckAdapter({scene, glContext});
 ```
 
 ## Parameters
 
-##### `scene` (`DeckScene`)
+##### `scene` (`DeckScene`, Optional)
 
 See [DeckScene](/docs/api-reference/scene/deck-scene) for more information.
+
+##### `glContext` (`WebGlContext`, Optional)
 
 ## Methods
 

--- a/docs/api-reference/encoder/preview-encoder.md
+++ b/docs/api-reference/encoder/preview-encoder.md
@@ -10,7 +10,7 @@ Construction of the encoder class is not required. Refer to [DeckAdapter.render]
 
 ```js
 import {DeckAdapter, PreviewEncoder} from '@hubble.gl/core'
-const adapter = new DeckAdapter(sceneBuilder);
+const adapter = new DeckAdapter({});
 
 adapter.render({Encoder: PreviewEncoder});
 ```

--- a/docs/api-reference/scene/deck-scene.md
+++ b/docs/api-reference/scene/deck-scene.md
@@ -3,9 +3,6 @@
 ## Usage
 
 ```js
-const width = 1280;
-const height = 720;
-
 const keyframes = {
   // Camera is optional unless animating the deck.gl viewState
   camera: new CameraKeyframes({...}) // camera is a reserved key
@@ -22,16 +19,14 @@ const getLayers = (scene) => {
 }
 
 const scene = new DeckScene({
-  initialKeyframes: keyframes, // optional
-  width,         // optional
-  height         // optional
+  initialKeyframes: keyframes // optional
 });
 ```
 
 ## Constructor
 
 ```js
-new DeckScene({});
+new DeckScene({timeline, initialKeyframes});
 ```
 
 Parameters:

--- a/examples/camera/app.js
+++ b/examples/camera/app.js
@@ -36,6 +36,11 @@ const timecode = {
   framerate: 30
 };
 
+const dimension = {
+  width: 640,
+  height: 480
+};
+
 const aaEffect = new PostProcessEffect(fxaa, {});
 const vignetteEffect = new PostProcessEffect(vignette, {});
 
@@ -72,13 +77,7 @@ export default function App() {
   }, [viewStateA, viewStateB]);
 
   const [adapter] = useState(
-    new DeckAdapter(
-      new DeckScene({
-        width: 640,
-        height: 480,
-        initialKeyframes: getKeyframes()
-      })
-    )
+    new DeckAdapter({scene: new DeckScene({initialKeyframes: getKeyframes()})})
   );
 
   return (
@@ -102,6 +101,8 @@ export default function App() {
         }}
         controller={true}
         effects={[vignetteEffect, aaEffect]}
+        width={dimension.width}
+        height={dimension.height}
         {...adapter.getProps({deck, onNextFrame, getLayers})}
       />
       <div style={{position: 'absolute'}}>

--- a/examples/quick-start/app.js
+++ b/examples/quick-start/app.js
@@ -15,6 +15,11 @@ const TIMECODE = {
   framerate: 30
 };
 
+const DIMENSION = {
+  width: 640,
+  height: 480
+};
+
 export default function App() {
   const getKeyframes = () => {
     return {
@@ -62,8 +67,8 @@ export default function App() {
   return (
     <QuickAnimation
       initialViewState={INITIAL_VIEW_STATE}
-      width={640}
-      height={480}
+      width={DIMENSION.width}
+      height={DIMENSION.height}
       getLayers={getLayers}
       getLayerKeyframes={getKeyframes}
       deckProps={{

--- a/examples/terrain/app.js
+++ b/examples/terrain/app.js
@@ -120,6 +120,13 @@ const timecode = {
   framerate: 30
 };
 
+const dimension = {
+  width: 640,
+  height: 480
+};
+
+const adapter = new DeckAdapter({scene: new DeckScene({initialKeyframes: getKeyframes()})});
+
 export default function App() {
   const deckRef = useRef(null);
   const deck = useMemo(() => deckRef.current && deckRef.current.deck, [deckRef.current]);
@@ -128,16 +135,6 @@ export default function App() {
 
   const onNextFrame = useNextFrame();
   const [rainbow, setRainbow] = useState(false);
-
-  const [adapter] = useState(
-    new DeckAdapter(
-      new DeckScene({
-        width: 640,
-        height: 480,
-        initialKeyframes: getKeyframes()
-      })
-    )
-  );
 
   const getLayers = scene => {
     const terrain = scene.keyframes.terrain.getFrame();
@@ -169,6 +166,8 @@ export default function App() {
           setViewState(vs);
         }}
         controller={true}
+        width={dimension.width}
+        height={dimension.height}
         {...adapter.getProps({deck, onNextFrame, getLayers})}
       />
       <div style={{position: 'absolute'}}>

--- a/examples/trips/app.js
+++ b/examples/trips/app.js
@@ -5,7 +5,7 @@
 
 import React, {useState, useRef, useEffect, useCallback, useMemo} from 'react';
 import DeckGL from '@deck.gl/react';
-import {DeckScene, DeckAdapter, CameraKeyframes} from '@hubble.gl/core';
+import {DeckAdapter, CameraKeyframes} from '@hubble.gl/core';
 import {useNextFrame, BasicControls} from '@hubble.gl/react';
 import {AmbientLight, PointLight, LightingEffect} from '@deck.gl/core';
 import {StaticMap} from 'react-map-gl';
@@ -88,15 +88,10 @@ const timecode = {
   framerate: 30
 };
 
-// Try to convert function to class
-// React.createRef
-//
-// useCallback
-// take onMaplOan outside of the class and call it to onMapLoans prop
-// equivalent to componentDidMount
-//
-// useEffect
-// similar to compontnetDidMount???
+const dimension = {
+  width: 1280,
+  height: 720
+};
 
 export default function App({
   mapStyle = 'mapbox://styles/mapbox/dark-v9',
@@ -117,25 +112,17 @@ export default function App({
   const [animation] = useState({});
   const [viewState, setViewState] = useState(INITIAL_VIEW_STATE);
 
-  const getDeckScene = timeline => {
-    return new DeckScene({
-      timeline,
-      width: 1280,
-      height: 720
-    });
-  };
-
-  const [adapter] = useState(new DeckAdapter(getDeckScene));
+  const [adapter] = useState(new DeckAdapter({}));
 
   const onMapLoad = useCallback(() => {
-    // Component did mount
-    const map = mapRef.current.getMap();
-    map.addLayer(new MapboxLayer({id: 'trips', deck}));
-    map.addLayer(new MapboxLayer({id: 'buildings', deck}));
-    map.addLayer(new MapboxLayer({id: 'ground', deck}));
-
-    map.on('render', () => adapter.onAfterRender(nextFrame));
-  }, []);
+    if (deck) {
+      const map = mapRef.current.getMap();
+      map.addLayer(new MapboxLayer({id: 'trips', deck}));
+      map.addLayer(new MapboxLayer({id: 'buildings', deck}));
+      map.addLayer(new MapboxLayer({id: 'ground', deck}));
+      map.on('render', () => adapter.onAfterRender(nextFrame));
+    }
+  }, [Boolean(deck)]);
 
   const animate = () => {
     setTime(t => (t + animationSpeed) % loopLength);
@@ -212,8 +199,6 @@ export default function App({
         layers={layers}
         effects={theme.effects}
         controller={true}
-        width={640}
-        height={480}
         viewState={viewState}
         onViewStateChange={({viewState: vs}) => {
           setViewState(vs);
@@ -226,6 +211,8 @@ export default function App({
           // blendEquation: GL.FUNC_ADD,
           blendFunc: [GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA]
         }}
+        width={dimension.width}
+        height={dimension.height}
         {...adapter.getProps({deck})}
       >
         {glContext && (

--- a/examples/worldview/src/features/map/Map.js
+++ b/examples/worldview/src/features/map/Map.js
@@ -115,7 +115,16 @@ export class Map extends Component {
   }
 
   render() {
-    const {adapter, viewState, width, height, setViewState, deckProps, staticMapProps} = this.props;
+    const {
+      adapter,
+      viewState,
+      width,
+      height,
+      setViewState,
+      deckProps,
+      staticMapProps,
+      dimension
+    } = this.props;
     const deck = this.deckRef.current && this.deckRef.current.deck;
 
     const deckStyle = {
@@ -141,6 +150,8 @@ export class Map extends Component {
           onWebGLInitialized={gl => this.setState({glContext: gl})}
           onViewStateChange={({viewState: vs}) => setViewState(vs)}
           // onClick={visStateActions.onLayerClick}
+          width={dimension.width}
+          height={dimension.height}
           {...adapter.getProps({deck, extraProps: deckProps})}
         >
           {this.state.glContext && (

--- a/examples/worldview/src/features/map/MapContainer.js
+++ b/examples/worldview/src/features/map/MapContainer.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import React, {useMemo, useEffect} from 'react';
-import {DeckAdapter, DeckScene} from '@hubble.gl/core';
+import {DeckAdapter} from '@hubble.gl/core';
 
 import {Map} from './Map';
 import {useDispatch, useSelector} from 'react-redux';
@@ -40,17 +40,7 @@ export const MapContainer = ({
   const dimension = useSelector(dimensionSelector);
   const viewState = useSelector(viewStateSelector);
 
-  const adapter = useMemo(
-    () =>
-      new DeckAdapter(
-        new DeckScene({
-          width: dimension.width,
-          height: dimension.height
-        }),
-        glContext
-      ),
-    [glContext, dimension]
-  );
+  const adapter = useMemo(() => new DeckAdapter({glContext}), [glContext]);
 
   useEffect(() => {
     dispatch(setupRenderer(adapter));

--- a/modules/core/src/adapters/deck-adapter.js
+++ b/modules/core/src/adapters/deck-adapter.js
@@ -36,11 +36,12 @@ export default class DeckAdapter {
   glContext;
 
   /**
-   * @param {DeckScene} scene
-   * @param {WebGL2RenderingContext} glContext
+   * @param {Object} params
+   * @param {DeckScene} params.scene
+   * @param {WebGL2RenderingContext} params.glContext
    */
-  constructor(scene, glContext = undefined) {
-    this.scene = scene;
+  constructor({scene = undefined, glContext = undefined}) {
+    this.scene = scene || new DeckScene({});
     this.glContext = glContext;
     this.videoCapture = new VideoCapture();
     this.shouldAnimate = true;
@@ -79,10 +80,6 @@ export default class DeckAdapter {
     if (getLayers) {
       props.layers = getLayers(this.scene);
     }
-
-    props.width = this.scene.width;
-    props.height = this.scene.height;
-    // props._timeline = this.scene.timeline; TODO: uncomment when shipped in deck.
 
     if (this.glContext) {
       props.gl = this.glContext;

--- a/modules/core/src/scene/deck-scene.js
+++ b/modules/core/src/scene/deck-scene.js
@@ -20,11 +20,13 @@
 import {Timeline} from '@luma.gl/engine';
 
 export default class DeckScene {
-  /** @param {import('types').DeckSceneParams} params */
-  constructor({timeline, width, height, initialKeyframes = undefined}) {
-    this.width = width;
-    this.height = height;
+  /**
+   * @param {Object} params
+   * @param {any} params.timeline
+   * @param {Object<string, import('keyframes').Keyframes>} params.initialKeyframes
+   */
 
+  constructor({timeline = undefined, initialKeyframes = undefined}) {
     this.timeline = timeline || new Timeline();
     this.keyframes = {};
     this.animations = {};

--- a/modules/core/src/types.d.ts
+++ b/modules/core/src/types.d.ts
@@ -47,8 +47,6 @@ interface FormatConfigs {
 
 interface DeckSceneParams {
   timeline: any
-  width: number
-  height: number
   initialKeyframes: Object<string, Keyframes>
 }
 

--- a/modules/react/src/components/export-video/export-video-panel-container.js
+++ b/modules/react/src/components/export-video/export-video-panel-container.js
@@ -22,7 +22,6 @@ import React, {Component} from 'react';
 import {easing} from 'popmotion';
 import {
   DeckAdapter,
-  DeckScene,
   CameraKeyframes,
   WebMEncoder,
   JPEGSequenceEncoder,
@@ -73,9 +72,7 @@ export class ExportVideoPanelContainer extends Component {
       rendering: false, // Will set a spinner overlay if true
       ...(initialState || {})
     };
-    const {width, height} = this.getCanvasSize();
-    const scene = new DeckScene({width, height});
-    this.state.adapter = new DeckAdapter(scene, glContext);
+    this.state.adapter = new DeckAdapter({glContext});
   }
 
   getFileName() {

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -175,7 +175,15 @@ export class ExportVideoPanelPreview extends Component {
   }
 
   render() {
-    const {exportVideoWidth, rendering, viewState, setViewState, adapter, durationMs} = this.props;
+    const {
+      exportVideoWidth,
+      rendering,
+      viewState,
+      setViewState,
+      adapter,
+      durationMs,
+      resolution
+    } = this.props;
     const {glContext, mapStyle} = this.state;
     const deck = this.deckRef.current && this.deckRef.current.deck;
     const containerStyle = {
@@ -197,6 +205,8 @@ export class ExportVideoPanelPreview extends Component {
             glOptions={{stencil: true}}
             onWebGLInitialized={gl => this.setState({glContext: gl})}
             onViewStateChange={setViewState}
+            width={resolution[0]}
+            height={resolution[1]}
             // onClick={visStateActions.onLayerClick}
             {...adapter.getProps({deck})}
           >

--- a/modules/react/src/components/quick-animation.js
+++ b/modules/react/src/components/quick-animation.js
@@ -24,15 +24,8 @@ export const QuickAnimation = ({
   const [viewState, setViewState] = useState(initialViewState);
 
   const adapter = useMemo(
-    () =>
-      new DeckAdapter(
-        new DeckScene({
-          width,
-          height,
-          initialKeyframes: getLayerKeyframes()
-        })
-      ),
-    [width, height]
+    () => new DeckAdapter({scene: new DeckScene({initialKeyframes: getLayerKeyframes()})}),
+    []
   );
 
   const mergedFormatConfigs = {
@@ -68,6 +61,8 @@ export const QuickAnimation = ({
           setViewState(vs);
         }}
         controller={true}
+        width={width}
+        height={height}
         {...adapter.getProps({deck, onNextFrame, getLayers, extraProps: deckProps})}
       />
       <div style={{position: 'absolute'}}>


### PR DESCRIPTION
Remove `width` and `height` from DeckScene so that the class is only focused on managing animation state. Instead provide DeckGl with width and height prop directly to control its render resolution. Note mapbox still determines its dimension by filling whatever container it is put in, so deck and mapbox should be set to the same value if used together.