### PR TITLE
[enhancement] split DeckScene keyframes up between layers and camera.

### DIFF
--- a/docs/api-reference/deck-adapter.md
+++ b/docs/api-reference/deck-adapter.md
@@ -30,7 +30,7 @@ Parameters:
 
 * `extraProps` (`DeckGlProps`, Optional) - Apply extra props to deckgl. Note: Hubble will override props as needed.
 
-##### `render({getCameraKeyframes, Encoder, formatConfigs, onStop, getKeyframes})`
+##### `render({getCameraKeyframes, Encoder, formatConfigs, onStop, getLayerKeyframes})`
 
 Start rendering.
 
@@ -40,9 +40,7 @@ Parameters:
 
 This function is used to access the camera's keyframes, and is called just prior to rendering.
 
-* **`getKeyframes` (`() => Object<string, Keyframes>`, Optional) - Default: `undefined`.**
-
-This function is called after the last frame is rendered and a file is created for download. It does not get called when a render is interrupted with `stop()`.
+* **`getLayerKeyframes` (`() => Object<string, Keyframes>`, Optional) - Default: `undefined`.**
 
 * **`Encoder` (`typeof FrameEncoder`, Optional) - Default: `PreviewEncoder`.**
 
@@ -68,7 +66,9 @@ Parameters:
 
 * `callback` (`() => void`, Optional) - Callback indicating the rendering is finished.
 
-##### `seek({timeMs, getCameraKeyframes, getKeyframes})`
+This function is called after the last frame is rendered and a file is created for download. It does not get called when a render is interrupted with `stop()`.
+
+##### `seek({timeMs, getCameraKeyframes, getLayerKeyframes})`
 
 Move time to set a new position. Useful for peeking at different times in an animation without rendering.
 
@@ -80,9 +80,7 @@ Parameters:
 
 This function is used to access the camera's keyframes, and is called just prior to rendering.
 
-* **`getKeyframes` (`() => Object<string, Keyframes>`, Optional) - Default: `undefined`.**
-
-This function is called after the last frame is rendered and a file is created for download. It does not get called when a render is interrupted with `stop()`.
+* **`getLayerKeyframes` (`() => Object<string, Keyframes>`, Optional) - Default: `undefined`.**
 
 ## Source
 

--- a/docs/api-reference/scene/deck-scene.md
+++ b/docs/api-reference/scene/deck-scene.md
@@ -22,7 +22,7 @@ const scene = new DeckScene({
 ## Constructor
 
 ```js
-new DeckScene({timeline, keyframes, cameraKeyframes});
+new DeckScene({timeline, layerKeyframes, cameraKeyframes});
 ```
 
 Parameters:
@@ -31,9 +31,9 @@ Parameters:
 
 Override the lumagl `timeline` object used in scene.
 
-##### `keyframes` (`Object<string, Keyframes>`, Optional)
+##### `layerKeyframes` (`Object<string, Keyframes>`, Optional)
 
-An initial set of keyframes. If they are static, supply them here. If the ever need to update, call `scene.setKeyframes`.
+An initial set of layer keyframes. If they are static, supply them here. If the ever need to update, call `scene.setLayerKeyframes`.
 
 ##### `cameraKeyframes` (`CameraKeyframes`, Optional)
 
@@ -41,28 +41,13 @@ An initial set of camera keyframes. If they are static, supply them here. If the
 
 ## Methods
 
-##### `getLayers` (`((scene: DeckScene) => any[]) => any[]`)
-
-A callback function to create deckgl layer objects provided the scene object.
-
-Returns:
-
-`Array` of deck.gl layers.
-
-##### `setKeyframes` (`Object`)
+##### `setLayerKeyframes` (`Object<string, Keyframes>`)
 
 Keyframe objects registered to the Timeline.
 
-- `camera` (`CameraKeyframes`, Optional) - supply a camera animation. If set, `deck.viewState` will be set with this keyframe object.
+##### `setCameraKeyframes` (`CameraKeyframes`)
 
-- Add additional keyframe objects to the object.
-
-The object is accessible in `getLayers` function via `scene.keyframes`.
-
-## Remarks
-
-- `camera` is a reserved object key within `keyframes`.
-
+Supply a camera animation. If set, `deck.viewState` will be set with this keyframe object.
 
 ## Source
 

--- a/docs/api-reference/scene/deck-scene.md
+++ b/docs/api-reference/scene/deck-scene.md
@@ -3,12 +3,8 @@
 ## Usage
 
 ```js
-const keyframes = {
-  // Camera is optional unless animating the deck.gl viewState
-  camera: new CameraKeyframes({...}) // camera is a reserved key
-}
-// Attach each keyframe object to timeline.
-timeline.attachAnimation(keyframes.camera);
+// Camera is optional unless animating the deck.gl viewState
+const cameraKeyframes = new CameraKeyframes({...})
 
 // Optional unless animating deck.gl layer properties.
 const getLayers = (scene) => {
@@ -19,14 +15,14 @@ const getLayers = (scene) => {
 }
 
 const scene = new DeckScene({
-  initialKeyframes: keyframes // optional
+  cameraKeyframes // optional
 });
 ```
 
 ## Constructor
 
 ```js
-new DeckScene({timeline, initialKeyframes});
+new DeckScene({timeline, keyframes, cameraKeyframes});
 ```
 
 Parameters:
@@ -35,9 +31,13 @@ Parameters:
 
 Override the lumagl `timeline` object used in scene.
 
-##### `initialKeyframes` (`Object<string, Keyframes>`, Optional)
+##### `keyframes` (`Object<string, Keyframes>`, Optional)
 
 An initial set of keyframes. If they are static, supply them here. If the ever need to update, call `scene.setKeyframes`.
+
+##### `cameraKeyframes` (`CameraKeyframes`, Optional)
+
+An initial set of camera keyframes. If they are static, supply them here. If the ever need to update, call `scene.setCameraKeyframes`.
 
 ## Methods
 

--- a/examples/camera/app.js
+++ b/examples/camera/app.js
@@ -76,9 +76,7 @@ export default function App() {
     });
   }, [viewStateA, viewStateB]);
 
-  const [adapter] = useState(
-    new DeckAdapter({scene: new DeckScene({initialKeyframes: getKeyframes()})})
-  );
+  const [adapter] = useState(new DeckAdapter({scene: new DeckScene({keyframes: getKeyframes()})}));
 
   return (
     <div style={{position: 'relative'}}>

--- a/examples/camera/app.js
+++ b/examples/camera/app.js
@@ -2,7 +2,7 @@ import React, {useState, useRef, useCallback, useMemo} from 'react';
 import DeckGL from '@deck.gl/react';
 import {DeckAdapter, DeckScene, CameraKeyframes} from '@hubble.gl/core';
 import {useNextFrame, BasicControls, ResolutionGuide} from '@hubble.gl/react';
-import {getLayers, getKeyframes} from './layers';
+import {getLayers, getLayerKeyframes} from './layers';
 import {vignette, fxaa} from '@luma.gl/shadertools';
 import {PostProcessEffect, MapView} from '@deck.gl/core';
 import {easing} from 'popmotion';
@@ -76,7 +76,9 @@ export default function App() {
     });
   }, [viewStateA, viewStateB]);
 
-  const [adapter] = useState(new DeckAdapter({scene: new DeckScene({keyframes: getKeyframes()})}));
+  const [adapter] = useState(
+    new DeckAdapter({scene: new DeckScene({layerKeyframes: getLayerKeyframes()})})
+  );
 
   return (
     <div style={{position: 'relative'}}>
@@ -111,7 +113,7 @@ export default function App() {
           formatConfigs={formatConfigs}
           timecode={timecode}
           getCameraKeyframes={getCameraKeyframes}
-          getKeyframes={getKeyframes}
+          getLayerKeyframes={getLayerKeyframes}
         />
         <button onClick={() => setViewStateA(filterCamera(viewState))}>Set Camera Start</button>
         <button onClick={() => setViewStateB(filterCamera(viewState))}>Set Camera End</button>

--- a/examples/camera/layers.js
+++ b/examples/camera/layers.js
@@ -10,8 +10,8 @@ const zipCodeData =
   'https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/sf-zipcodes.json';
 
 export function getLayers(scene) {
-  const stationFrame = scene.keyframes.station.getFrame();
-  const textFrame = scene.keyframes.text.getFrame();
+  const stationFrame = scene.layerKeyframes.station.getFrame();
+  const textFrame = scene.layerKeyframes.text.getFrame();
   return [
     new PolygonLayer({
       id: 'polygon-layer',
@@ -81,7 +81,7 @@ export function getLayers(scene) {
   ];
 }
 
-export const getKeyframes = () => {
+export const getLayerKeyframes = () => {
   return {
     station: new LayerKeyframes({
       layerId: 'scatterplot-layer',

--- a/examples/quick-start/app.js
+++ b/examples/quick-start/app.js
@@ -21,7 +21,7 @@ const DIMENSION = {
 };
 
 export default function App() {
-  const getKeyframes = () => {
+  const getLayerKeyframes = () => {
     return {
       circle: new Keyframes({
         features: ['opacity', 'radiusScale'],
@@ -49,8 +49,8 @@ export default function App() {
     };
   };
   const getLayers = scene => {
-    const circleFrame = scene.keyframes.circle.getFrame();
-    const textFrame = scene.keyframes.text.getFrame();
+    const circleFrame = scene.layerKeyframes.circle.getFrame();
+    const textFrame = scene.layerKeyframes.text.getFrame();
     return [
       new ScatterplotLayer({
         data: [{position: [-122.402, 37.79], color: [255, 0, 0], radius: 1000}],
@@ -70,7 +70,7 @@ export default function App() {
       width={DIMENSION.width}
       height={DIMENSION.height}
       getLayers={getLayers}
-      getLayerKeyframes={getKeyframes}
+      getLayerKeyframes={getLayerKeyframes}
       deckProps={{
         parameters: {
           clearColor: [255, 255, 255, 1]

--- a/examples/quick-start/quick-start-after.js
+++ b/examples/quick-start/quick-start-after.js
@@ -16,7 +16,7 @@ const TIMECODE = {
 };
 
 export default function App() {
-  const getKeyframes = () => {
+  const getLayerKeyframes = () => {
     return {
       circle: new Keyframes({
         features: ['opacity', 'radiusScale'],
@@ -44,8 +44,8 @@ export default function App() {
   };
 
   const getLayers = scene => {
-    const circleFrame = scene.keyframes.circle.getFrame();
-    const textFrame = scene.keyframes.text.getFrame();
+    const circleFrame = scene.layerKeyframes.circle.getFrame();
+    const textFrame = scene.layerKeyframes.text.getFrame();
     return [
       new ScatterplotLayer({
         data: [{position: [-122.402, 37.79], color: [255, 0, 0], radius: 1000}],
@@ -66,7 +66,7 @@ export default function App() {
       width={640}
       height={480}
       getLayers={getLayers}
-      getLayerKeyframes={getKeyframes}
+      getLayerKeyframes={getLayerKeyframes}
       deckProps={{
         parameters: {
           clearColor: [255, 255, 255, 1]

--- a/examples/terrain/app.js
+++ b/examples/terrain/app.js
@@ -72,7 +72,7 @@ const getCameraKeyframes = () => {
   });
 };
 
-const getKeyframes = () => {
+const getLayerKeyframes = () => {
   return {
     terrain: new LayerKeyframes({
       layerId: 'terrain',
@@ -126,7 +126,7 @@ const dimension = {
 };
 
 const adapter = new DeckAdapter({
-  scene: new DeckScene({keyframes: getKeyframes(), cameraKeyframes: getCameraKeyframes()})
+  scene: new DeckScene({layerKeyframes: getLayerKeyframes(), cameraKeyframes: getCameraKeyframes()})
 });
 
 export default function App() {
@@ -139,7 +139,7 @@ export default function App() {
   const [rainbow, setRainbow] = useState(false);
 
   const getLayers = scene => {
-    const terrain = scene.keyframes.terrain.getFrame();
+    const terrain = scene.layerKeyframes.terrain.getFrame();
     return [
       new TerrainLayer({
         id: 'terrain',
@@ -180,7 +180,7 @@ export default function App() {
           formatConfigs={formatConfigs}
           timecode={timecode}
           getCameraKeyframes={getCameraKeyframes}
-          getKeyframes={getKeyframes}
+          getLayerKeyframes={getLayerKeyframes}
         />
         <div style={{backgroundColor: 'rgba(255, 255, 255, 0.5)'}}>
           <label style={{fontFamily: 'sans-serif'}}>

--- a/examples/terrain/app.js
+++ b/examples/terrain/app.js
@@ -125,7 +125,9 @@ const dimension = {
   height: 480
 };
 
-const adapter = new DeckAdapter({scene: new DeckScene({initialKeyframes: getKeyframes()})});
+const adapter = new DeckAdapter({
+  scene: new DeckScene({keyframes: getKeyframes(), cameraKeyframes: getCameraKeyframes()})
+});
 
 export default function App() {
   const deckRef = useRef(null);

--- a/examples/worldview/src/app/App.js
+++ b/examples/worldview/src/app/App.js
@@ -88,7 +88,7 @@ const sceneLayers = [];
 const App = ({}) => {
   useKepler(KEPLER_MAP_ID);
   const keplerLayers = useSelector(selectKeplerLayers);
-  const getKeyframes = useKeplerKeyframes(keplerLayers);
+  const getLayerKeyframes = useKeplerKeyframes(keplerLayers);
   useKeplerFrame(keplerLayers);
   const keplerDeckLayers = useKeplerDeckLayers(KEPLER_MAP_ID);
   const deckProps = useMemo(() => {
@@ -114,7 +114,7 @@ const App = ({}) => {
             <InjectKeplerUI keplerUI={KEPLER_UI}>
               <div style={{height: 1080, margin: 16}}>
                 <MonitorPanel
-                  getKeyframes={getKeyframes}
+                  getLayerKeyframes={getLayerKeyframes}
                   deckProps={deckProps}
                   staticMapProps={staticMapProps}
                 />

--- a/examples/worldview/src/features/kepler/hooks.js
+++ b/examples/worldview/src/features/kepler/hooks.js
@@ -12,7 +12,7 @@ import {createSelector} from 'reselect';
 import {
   filterKeyframeSelector,
   layerKeyframeSelector,
-  frameSelector,
+  frameLayerSelector,
   tripLayerKeyframeSelector
 } from '../timeline/timelineSlice';
 import {AUTH_TOKENS} from '../../constants';
@@ -93,7 +93,7 @@ export const useKeplerKeyframes = keplerLayers => {
 
 export const useKeplerFrame = (keplerLayers = []) => {
   const dispatch = useDispatch();
-  const frame = useSelector(frameSelector);
+  const frame = useSelector(frameLayerSelector);
 
   useEffect(() => {
     // Filter Frame

--- a/examples/worldview/src/features/monitor/MonitorPanel.js
+++ b/examples/worldview/src/features/monitor/MonitorPanel.js
@@ -128,19 +128,19 @@ const MapBox = styled.div`
   height: ${props => props.height}px;
 `;
 
-const SeekSlider = ({getCameraKeyframes, getKeyframes}) => {
+const SeekSlider = ({getCameraKeyframes, getLayerKeyframes}) => {
   const timecode = useSelector(timecodeSelector);
   const framestep = useSelector(framestepSelector);
   const dispatch = useDispatch();
   const onSeek = useCallback(
     timeMs => {
-      if (getCameraKeyframes && getKeyframes) {
-        dispatch(seekTime({timeMs, getCameraKeyframes, getKeyframes}));
+      if (getCameraKeyframes && getLayerKeyframes) {
+        dispatch(seekTime({timeMs, getCameraKeyframes, getLayerKeyframes}));
       }
     },
-    [getCameraKeyframes, getKeyframes]
+    [getCameraKeyframes, getLayerKeyframes]
   );
-  // useEffect(() => onSeek(timecode.start), [timecode.start, getCameraKeyframes, getKeyframes])
+  // useEffect(() => onSeek(timecode.start), [timecode.start, getCameraKeyframes, getLayerKeyframes])
 
   return (
     <input
@@ -155,7 +155,7 @@ const SeekSlider = ({getCameraKeyframes, getKeyframes}) => {
 
 export const MonitorPanel = ({
   getCameraKeyframes = undefined,
-  getKeyframes,
+  getLayerKeyframes,
   deckProps = undefined,
   staticMapProps = undefined
 }) => {
@@ -169,8 +169,8 @@ export const MonitorPanel = ({
 
   useCameraFrame();
   const prepareFrame = usePrepareFrame();
-  const onPreview = usePreviewHandler({getCameraKeyframes, getKeyframes});
-  const onRender = useRenderHandler({getCameraKeyframes, getKeyframes});
+  const onPreview = usePreviewHandler({getCameraKeyframes, getLayerKeyframes});
+  const onRender = useRenderHandler({getCameraKeyframes, getLayerKeyframes});
 
   return (
     <div
@@ -209,7 +209,7 @@ export const MonitorPanel = ({
       </div>
       <MonitorBottomToolbar playing={Boolean(rendererBusy)} onPreview={onPreview} />
       <button onClick={onRender}>Render</button>
-      <SeekSlider getCameraKeyframes={getCameraKeyframes} getKeyframes={getKeyframes} />
+      <SeekSlider getCameraKeyframes={getCameraKeyframes} getLayerKeyframes={getLayerKeyframes} />
     </div>
   );
 };

--- a/examples/worldview/src/features/renderer/hooks.js
+++ b/examples/worldview/src/features/renderer/hooks.js
@@ -2,28 +2,28 @@ import {busySelector, previewVideo, stopVideo, renderVideo} from '../renderer';
 import {useCallback} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
-export function usePreviewHandler({getCameraKeyframes, getKeyframes}) {
+export function usePreviewHandler({getCameraKeyframes, getLayerKeyframes}) {
   const rendererBusy = useSelector(busySelector);
   const dispatch = useDispatch();
   const handlePreview = useCallback(() => {
     if (rendererBusy === false) {
-      dispatch(previewVideo({getCameraKeyframes, getKeyframes}));
+      dispatch(previewVideo({getCameraKeyframes, getLayerKeyframes}));
     } else {
       dispatch(stopVideo());
     }
-  }, [rendererBusy, getCameraKeyframes, getKeyframes]);
+  }, [rendererBusy, getCameraKeyframes, getLayerKeyframes]);
   return handlePreview;
 }
 
-export function useRenderHandler({getCameraKeyframes, getKeyframes}) {
+export function useRenderHandler({getCameraKeyframes, getLayerKeyframes}) {
   const rendererBusy = useSelector(busySelector);
   const dispatch = useDispatch();
   const handleRender = useCallback(() => {
     if (rendererBusy === false) {
-      dispatch(renderVideo({getCameraKeyframes, getKeyframes}));
+      dispatch(renderVideo({getCameraKeyframes, getLayerKeyframes}));
     } else {
       dispatch(stopVideo());
     }
-  }, [rendererBusy, getCameraKeyframes, getKeyframes]);
+  }, [rendererBusy, getCameraKeyframes, getLayerKeyframes]);
   return handleRender;
 }

--- a/examples/worldview/src/features/renderer/rendererMiddleware.js
+++ b/examples/worldview/src/features/renderer/rendererMiddleware.js
@@ -49,7 +49,7 @@ export const rendererMiddleware = store => {
         break;
       }
       case previewVideo.type: {
-        const {getCameraKeyframes, getKeyframes, onStop} = action.payload;
+        const {getCameraKeyframes, getLayerKeyframes, onStop} = action.payload;
         const state = store.getState();
         store.dispatch(signalPreviewing(true));
         const innerOnStop = () => {
@@ -64,12 +64,12 @@ export const rendererMiddleware = store => {
           timecode: timecodeSelector(state),
           filename: filenameSelector(state),
           onStop: innerOnStop,
-          getKeyframes
+          getLayerKeyframes
         });
         break;
       }
       case renderVideo.type: {
-        const {getCameraKeyframes, getKeyframes, onStop} = action.payload;
+        const {getCameraKeyframes, getLayerKeyframes, onStop} = action.payload;
         const state = store.getState();
         const Encoder = encoderSelector(state);
 
@@ -87,7 +87,7 @@ export const rendererMiddleware = store => {
           timecode: timecodeSelector(state),
           filename: filenameSelector(state),
           onStop: innerOnStop,
-          getKeyframes
+          getLayerKeyframes
         });
 
         break;

--- a/examples/worldview/src/features/renderer/rendererMiddleware.js
+++ b/examples/worldview/src/features/renderer/rendererMiddleware.js
@@ -6,7 +6,7 @@ import {
   PreviewEncoder,
   GifEncoder
 } from '@hubble.gl/core';
-import {updateFrame} from '../timeline/timelineSlice';
+import {updateLayerFrame, updateCameraFrame} from '../timeline/timelineSlice';
 
 import {
   setupRenderer,
@@ -103,14 +103,8 @@ export const rendererMiddleware = store => {
       case seekTime.type: {
         if (!busySelector(store.getState()) && adapter && adapter.scene) {
           adapter.seek(action.payload);
-          const sceneFrame = Object.entries(adapter.scene.keyframes).reduce(
-            (frame, [key, keyframe]) => {
-              frame[key] = keyframe.getFrame();
-              return frame;
-            },
-            {}
-          );
-          store.dispatch(updateFrame(sceneFrame));
+          store.dispatch(updateCameraFrame(adapter.scene.getCameraFrame()));
+          store.dispatch(updateLayerFrame(adapter.scene.getLayerFrame()));
         }
         break;
       }

--- a/examples/worldview/src/features/renderer/rendererSlice.js
+++ b/examples/worldview/src/features/renderer/rendererSlice.js
@@ -11,7 +11,7 @@ export const previewVideo = createAction('renderer/previewVideo');
 /** @param payload: getCameraKeyframes, onStop */
 export const renderVideo = createAction('renderer/renderVideo');
 
-/** @param payload: timeMs, getCameraKeyframes, getKeyframes */
+/** @param payload: timeMs, getCameraKeyframes, getLayerKeyframes */
 export const seekTime = createAction('renderer/seekTime');
 
 /** @param payload: boolean */

--- a/examples/worldview/src/features/timeline/hooks.js
+++ b/examples/worldview/src/features/timeline/hooks.js
@@ -2,7 +2,12 @@ import {useCallback, useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {CameraKeyframes} from '@hubble.gl/core';
 
-import {cameraKeyframeSelector, frameSelector, updateFrame} from './timelineSlice';
+import {
+  cameraKeyframeSelector,
+  cameraFrameSelector,
+  updateLayerFrame,
+  updateCameraFrame
+} from './timelineSlice';
 import {dimensionSelector} from '../renderer';
 import {updateViewState} from '../map';
 
@@ -23,22 +28,18 @@ export function useCameraKeyframes() {
 
 export function useCameraFrame() {
   const dispatch = useDispatch();
-  const frame = useSelector(frameSelector);
+  const cameraFrame = useSelector(cameraFrameSelector);
   useEffect(() => {
-    if (frame.camera) {
-      dispatch(updateViewState(frame.camera));
+    if (cameraFrame) {
+      dispatch(updateViewState(cameraFrame));
     }
-  }, [frame]);
+  }, [cameraFrame]);
 }
 
 export function usePrepareFrame() {
   const dispatch = useDispatch();
-  const prepareFrame = useCallback(scene => {
-    const sceneFrame = Object.entries(scene.keyframes).reduce((frame, [key, keyframe]) => {
-      frame[key] = keyframe.getFrame();
-      return frame;
-    }, {});
-    dispatch(updateFrame(sceneFrame));
+  return useCallback(scene => {
+    dispatch(updateCameraFrame(scene.getCameraFrame()));
+    dispatch(updateLayerFrame(scene.getLayerFrame()));
   });
-  return prepareFrame;
 }

--- a/examples/worldview/src/features/timeline/timelineSlice.js
+++ b/examples/worldview/src/features/timeline/timelineSlice.js
@@ -6,7 +6,8 @@ const initialState = {
   filterKeyframes: undefined, // keyframe object
   tripLayerKeyframes: undefined, // keyframe object
   layerKeyframes: {}, // name: keyframe object
-  frame: {}
+  layerFrame: {},
+  cameraFrame: undefined // mapState
 };
 
 const timelineSlice = createSlice({
@@ -18,7 +19,8 @@ const timelineSlice = createSlice({
     updateTripLayerKeyframes: (state, action) => void (state.tripLayerKeyframes = action.payload),
     updateLayerKeyframes: (state, action) =>
       void (state.layerKeyframes = {...state.layerKeyframes, ...action.payload}),
-    updateFrame: (state, action) => void (state.frame = action.payload)
+    updateLayerFrame: (state, action) => void (state.frame = action.payload),
+    updateCameraFrame: (state, action) => void (state.cameraFrame = action.payload)
   }
 });
 
@@ -27,7 +29,8 @@ export const {
   updateFilterKeyframes,
   updateLayerKeyframes,
   updateTripLayerKeyframes,
-  updateFrame
+  updateLayerFrame,
+  updateCameraFrame
 } = timelineSlice.actions;
 
 export default timelineSlice.reducer;
@@ -40,4 +43,5 @@ export const cameraKeyframeSelector = state => state.hubbleGl.timeline.cameraKey
 export const filterKeyframeSelector = state => state.hubbleGl.timeline.filterKeyframes;
 export const tripLayerKeyframeSelector = state => state.hubbleGl.timeline.tripLayerKeyframes;
 export const layerKeyframeSelector = state => state.hubbleGl.timeline.layerKeyframes;
-export const frameSelector = state => state.hubbleGl.timeline.frame;
+export const frameLayerSelector = state => state.hubbleGl.timeline.layerFrame;
+export const cameraFrameSelector = state => state.hubbleGl.timeline.cameraFrame;

--- a/modules/core/src/adapters/deck-adapter.js
+++ b/modules/core/src/adapters/deck-adapter.js
@@ -90,7 +90,7 @@ export default class DeckAdapter {
   /**
    * @param {Object} params
    * @param {() => import('../keyframes').CameraKeyframes} params.getCameraKeyframes
-   * @param {() => Object<string, import('../keyframes').Keyframes>} params.getKeyframes
+   * @param {() => Object<string, import('../keyframes').Keyframes>} params.getLayerKeyframes
    * @param {typeof import('../encoders').FrameEncoder} params.Encoder
    * @param {Partial<import('types').FormatConfigs>} params.formatConfigs
    * @param {() => void} params.onStop
@@ -99,7 +99,7 @@ export default class DeckAdapter {
    */
   render({
     getCameraKeyframes = undefined,
-    getKeyframes = undefined,
+    getLayerKeyframes = undefined,
     Encoder = PreviewEncoder,
     formatConfigs = {},
     onStop = undefined,
@@ -109,8 +109,8 @@ export default class DeckAdapter {
     if (getCameraKeyframes) {
       this.scene.setCameraKeyframes(getCameraKeyframes());
     }
-    if (getKeyframes) {
-      this.scene.setKeyframes(getKeyframes());
+    if (getLayerKeyframes) {
+      this.scene.setLayerKeyframes(getLayerKeyframes());
     }
 
     const innerOnStop = () => {
@@ -138,14 +138,14 @@ export default class DeckAdapter {
    * @param {Object} params
    * @param {number} params.timeMs
    * @param {() => import('../keyframes').CameraKeyframes} params.getCameraKeyframes
-   * @param {() => Object<string, import('../keyframes').Keyframes>} params.getKeyframes
+   * @param {() => Object<string, import('../keyframes').Keyframes>} params.getLayerKeyframes
    */
-  seek({timeMs, getCameraKeyframes = undefined, getKeyframes = undefined}) {
+  seek({timeMs, getCameraKeyframes = undefined, getLayerKeyframes = undefined}) {
     if (getCameraKeyframes) {
       this.scene.setCameraKeyframes(getCameraKeyframes());
     }
-    if (getKeyframes) {
-      this.scene.setKeyframes(getKeyframes());
+    if (getLayerKeyframes) {
+      this.scene.setLayerKeyframes(getLayerKeyframes());
     }
     this.scene.timeline.setTime(timeMs);
   }

--- a/modules/core/src/adapters/deck-adapter.js
+++ b/modules/core/src/adapters/deck-adapter.js
@@ -70,9 +70,9 @@ export default class DeckAdapter {
     }
 
     // Animating the camera is optional, but if a keyframe is defined then viewState is controlled by camera keyframe.
-    if (this.scene.keyframes.camera && this.enabled) {
+    if (this.scene.cameraKeyframes && this.enabled) {
       props.controller = false;
-      props.viewState = this.scene.keyframes.camera.getFrame();
+      props.viewState = this.scene.getCameraFrame();
     }
 
     // Construct layers using callback.

--- a/modules/core/src/keyframes/keyframes.js
+++ b/modules/core/src/keyframes/keyframes.js
@@ -28,6 +28,7 @@ import {
 
 class Keyframes extends LumaKeyFrames {
   activeFeatures = {};
+  animationHandle;
   constructor({features, timings, keyframes, easings, interpolators = 'linear'}) {
     super([]);
     this._setActiveFeatures = this._setActiveFeatures.bind(this);

--- a/modules/core/src/types.d.ts
+++ b/modules/core/src/types.d.ts
@@ -1,4 +1,4 @@
-import { Keyframes } from "./keyframes";
+import { Keyframes, CameraKeyframes } from "./keyframes";
 import { FrameEncoder } from "./encoders";
 import { DeckScene } from "./scene";
 
@@ -47,7 +47,8 @@ interface FormatConfigs {
 
 interface DeckSceneParams {
   timeline: any
-  initialKeyframes: Object<string, Keyframes>
+  layerKeyframes: Object<string, Keyframes>
+  cameraKeyframes: CameraKeyframes
 }
 
 interface KeplerSceneParams {

--- a/modules/react/src/components/basic-controls.js
+++ b/modules/react/src/components/basic-controls.js
@@ -43,14 +43,14 @@ export default function BasicControls({
   formatConfigs,
   timecode,
   getCameraKeyframes,
-  getKeyframes = undefined
+  getLayerKeyframes = undefined
 }) {
   const [encoder, setEncoder] = useState('gif');
 
   const onRender = () => {
     adapter.render({
       getCameraKeyframes,
-      getKeyframes,
+      getLayerKeyframes,
       Encoder: ENCODERS[encoder],
       formatConfigs,
       timecode,

--- a/modules/react/src/components/quick-animation.js
+++ b/modules/react/src/components/quick-animation.js
@@ -24,7 +24,7 @@ export const QuickAnimation = ({
   const [viewState, setViewState] = useState(initialViewState);
 
   const adapter = useMemo(
-    () => new DeckAdapter({scene: new DeckScene({initialKeyframes: getLayerKeyframes()})}),
+    () => new DeckAdapter({scene: new DeckScene({keyframes: getLayerKeyframes()})}),
     []
   );
 

--- a/modules/react/src/components/quick-animation.js
+++ b/modules/react/src/components/quick-animation.js
@@ -24,7 +24,7 @@ export const QuickAnimation = ({
   const [viewState, setViewState] = useState(initialViewState);
 
   const adapter = useMemo(
-    () => new DeckAdapter({scene: new DeckScene({keyframes: getLayerKeyframes()})}),
+    () => new DeckAdapter({scene: new DeckScene({layerKeyframes: getLayerKeyframes()})}),
     []
   );
 
@@ -72,10 +72,8 @@ export const QuickAnimation = ({
           setBusy={setBusy}
           formatConfigs={mergedFormatConfigs}
           timecode={mergedTimecode}
-          getCameraKeyframes={
-            getCameraKeyframes ? () => getCameraKeyframes(viewState) : getCameraKeyframes
-          }
-          getKeyframes={getLayerKeyframes}
+          getCameraKeyframes={getCameraKeyframes && (() => getCameraKeyframes(viewState))}
+          getLayerKeyframes={getLayerKeyframes}
         />
       </div>
     </div>


### PR DESCRIPTION
**Changes**

- Instead of reserving `camera` key in keyframes object, give it a dedicated variable in DeckScene.
- For DeckScene construction, `initialKeyframes` split into `cameraKeyframes` and `layerKeyframes`.
- Added `scene.setCameraKeyframes` and `scene.getCameraFrame`

**Renamed**
- `scene.setKeyframes` to `scene.setLayerKeyframes`
- `scene.getFrame` to `scene.getLayerFrame`
- `scene.keyframes` to `scene.layerKeyframes`. Added `scene.cameraKeyframes`
- `getKeyframes` parameter renamed to `getLayerKeyframes` throughout DeckAdapter and examples.
