### PR TITLE
Button within "Share" to export Hubble Modal

### DIFF
--- a/examples/kepler-integration/src/actions.js
+++ b/examples/kepler-integration/src/actions.js
@@ -33,6 +33,7 @@ export const LOAD_REMOTE_RESOURCE_SUCCESS = 'LOAD_REMOTE_RESOURCE_SUCCESS';
 export const LOAD_REMOTE_RESOURCE_ERROR = 'LOAD_REMOTE_RESOURCE_ERROR';
 export const LOAD_MAP_SAMPLE_FILE = 'LOAD_MAP_SAMPLE_FILE';
 export const SET_SAMPLE_LOADING_STATUS = 'SET_SAMPLE_LOADING_STATUS';
+export const VIDEO_MODAL_MODE = 'VIDEO_MODAL_MODE';
 
 // ACTIONS
 export function initApp() {
@@ -69,6 +70,13 @@ export function setLoadingMapStatus(isMapLoading) {
   return {
     type: SET_SAMPLE_LOADING_STATUS,
     isMapLoading
+  };
+}
+
+export function toggleHubbleExportModal(isVideoModalOpen) {
+  return {
+    type: VIDEO_MODAL_MODE,
+    isVideoModalOpen
   };
 }
 

--- a/examples/kepler-integration/src/app.js
+++ b/examples/kepler-integration/src/app.js
@@ -29,6 +29,7 @@ import {theme} from 'kepler.gl/styles';
 import {replaceLoadDataModal} from './factories/load-data-modal';
 import {replaceMapControl} from './factories/map-control';
 import {replacePanelHeader} from './factories/panel-header';
+import {replaceSaveExportDropdown} from './factories/export-modal';
 import {AUTH_TOKENS} from './constants/default-settings';
 import {loadSampleConfigurations} from './actions';
 
@@ -45,7 +46,8 @@ import {processCsvData, processGeojson} from 'kepler.gl/processors';
 const KeplerGl = require('kepler.gl/components').injectComponents([
   replaceLoadDataModal(),
   replaceMapControl(),
-  replacePanelHeader()
+  replacePanelHeader(),
+  replaceSaveExportDropdown()
 ]);
 
 const keplerGlGetState = state => state.demo.keplerGl;

--- a/examples/kepler-integration/src/components/export-video.js
+++ b/examples/kepler-integration/src/components/export-video.js
@@ -37,7 +37,7 @@ import {
 
 // Redux stores/actions
 // import {connect as keplerGlConnect} from 'kepler.gl';
-import toggleHubbleExportModal from 'kepler.gl'; // TODO make custom action
+import {toggleHubbleExportModal} from '../actions';
 
 const IconButton = styled(Button)`
   padding: 0;
@@ -58,7 +58,7 @@ const KEPLER_UI = {
 };
 
 const mapStateToProps = state => {
-  return {mapData: state.demo.keplerGl.map};
+  return {mapData: state.demo.keplerGl.map, isVideoModalOpen: state.demo.app.isVideoModalOpen};
 };
 
 // NOTE: This commented out code is here to connect to Redux store in future
@@ -80,7 +80,7 @@ const mapStateToProps = state => {
 // const mapDispatchToProps = () => (noResultDispatch, ownProps, dispatch) => {
 const mapDispatchToProps = () => (dispatch, props) => {
   return {
-    toggleHubbleExportModal: isOpen => dispatch(toggleHubbleExportModal(isOpen)) // NOTE gives dispatch error
+    toggleHubbleExportModal: isVideoModalOpen => dispatch(toggleHubbleExportModal(isVideoModalOpen)) // NOTE gives dispatch error
   };
 };
 
@@ -88,28 +88,32 @@ class ExportVideo extends Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      isOpen: false
-    };
+    // this.state = {
+    //   isOpen: false
+    // };
     this.handleClose = this.handleClose.bind(this);
     this.handleOpen = this.handleOpen.bind(this);
   }
 
   // NOTE: This commented out code is here to connect to Redux store in future
-  // handleClose() {this.props.toggleHubbleExportModal(false)} // X button in ExportVideoModal was clicked
-  // handleOpen() {this.props.toggleHubbleExportModal(true)} // Export button in Kepler UI was clicked
   handleClose() {
-    this.setState({isOpen: false});
+    this.props.toggleHubbleExportModal(false);
   } // X button in ExportVideoModal was clicked
   handleOpen() {
-    this.setState({isOpen: true});
+    this.props.toggleHubbleExportModal(true);
   } // Export button in Kepler UI was clicked
+  // handleClose() {
+  //   this.setState({isOpen: false});
+  // } // X button in ExportVideoModal was clicked
+  // handleOpen() {
+  //   this.setState({isOpen: true});
+  // } // Export button in Kepler UI was clicked
 
   render() {
     return (
       <InjectKeplerUI keplerUI={KEPLER_UI}>
         <div>
-          <ExportVideoModal isOpen={this.state.isOpen} theme={this.props.theme}>
+          <ExportVideoModal isOpen={this.props.isVideoModalOpen} theme={this.props.theme}>
             <ExportVideoPanelContainer
               handleClose={this.handleClose}
               mapData={this.props.mapData}

--- a/examples/kepler-integration/src/factories/export-modal.js
+++ b/examples/kepler-integration/src/factories/export-modal.js
@@ -1,0 +1,34 @@
+import {SaveExportDropdownFactory, withState} from 'kepler.gl/components';
+import {toggleHubbleExportModal} from '../actions';
+import {Icons} from 'kepler.gl/components';
+
+// TODO panel-header finds certain items. Figure out how and add new one
+const CustomSaveExportDropdownFactory = (...deps) => {
+  const SaveExportDropdown = SaveExportDropdownFactory(...deps);
+  const defaultLoadingMethods = SaveExportDropdown.defaultProps.items;
+
+  const exportVideoModal = {
+    label: 'toolbar.exportVideoModal',
+    icon: Icons.Files, // TODO Temp icon
+    key: 'video',
+    onClick: props => unusedPanelHeaderProps => props.toggleHubbleExportModal(true) // Normally expects props from PanelHeaderFactory
+    // but this is being used as part of Hubble. Otherwise will get filtered out. Reference https://github.com/keplergl/kepler.gl/blob/master/src/components/side-panel/panel-header.js#L139
+    // TODO load hubble modal https://twitter.com/dan_abramov/status/824308413559668744?lang=en
+  };
+  // console.log("SaveExportDropdown.defaultProps", SaveExportDropdown.defaultProps)
+  // console.log("defaultLoadingMethods", defaultLoadingMethods)
+  // add more loading methods
+  SaveExportDropdown.defaultProps = {
+    ...SaveExportDropdown.defaultProps,
+    items: [...defaultLoadingMethods, exportVideoModal]
+  };
+  // console.log('SaveExportDropdown.defaultProps', SaveExportDropdown.defaultProps);
+
+  return withState([], () => {}, {toggleHubbleExportModal})(SaveExportDropdown);
+};
+
+CustomSaveExportDropdownFactory.deps = SaveExportDropdownFactory.deps;
+
+export function replaceSaveExportDropdown() {
+  return [SaveExportDropdownFactory, CustomSaveExportDropdownFactory];
+}

--- a/examples/kepler-integration/src/reducers/index.js
+++ b/examples/kepler-integration/src/reducers/index.js
@@ -31,7 +31,8 @@ import {
   LOAD_MAP_SAMPLE_FILE,
   LOAD_REMOTE_RESOURCE_SUCCESS,
   LOAD_REMOTE_RESOURCE_ERROR,
-  SET_SAMPLE_LOADING_STATUS
+  SET_SAMPLE_LOADING_STATUS,
+  VIDEO_MODAL_MODE
 } from '../actions';
 
 import {AUTH_TOKENS, DEFAULT_FEATURE_FLAGS} from '../constants/default-settings';
@@ -49,7 +50,8 @@ const initialAppState = {
   //   message: null
   // }
   // eventually we may have an async process to fetch these from a remote location
-  featureFlags: DEFAULT_FEATURE_FLAGS
+  featureFlags: DEFAULT_FEATURE_FLAGS,
+  isVideoModalOpen: false
 };
 
 // App reducer
@@ -66,6 +68,11 @@ export const appReducer = handleActions(
     [SET_SAMPLE_LOADING_STATUS]: (state, action) => ({
       ...state,
       isMapLoading: action.isMapLoading
+    }),
+    [VIDEO_MODAL_MODE]: (state, action) => ({
+      // TODO Think of better name
+      ...state,
+      isVideoModalOpen: action.isVideoModalOpen
     })
   },
   initialAppState


### PR DESCRIPTION
# Changelog
- Injected Hubble Export modal into Kepler UI. Now a new button to export video will show up under "Share" icon.
- Opening/closing of the modal is now controlled by Redux actions
- 

# Known Issues
- Pressing the export button at the top or under share breaks with the following error (possibly local issue only): 

![image](https://user-images.githubusercontent.com/33266041/123700815-d1c20b80-d815-11eb-9b51-1e2d13b5efec.png)
