### PR TITLE
[enhancement] Add adapter to worldview store, initialized immediately

### DIFF
--- a/examples/worldview/src/features/map/MapContainer.js
+++ b/examples/worldview/src/features/map/MapContainer.js
@@ -18,13 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {useMemo, useEffect} from 'react';
-import {DeckAdapter} from '@hubble.gl/core';
+import React from 'react';
 
 import {Map} from './Map';
 import {useDispatch, useSelector} from 'react-redux';
 
-import {setupRenderer, dimensionSelector} from '../renderer';
+import {dimensionSelector, adapterSelector} from '../renderer';
 
 import {updateViewState, viewStateSelector} from './mapSlice';
 
@@ -39,12 +38,7 @@ export const MapContainer = ({
   const dispatch = useDispatch();
   const dimension = useSelector(dimensionSelector);
   const viewState = useSelector(viewStateSelector);
-
-  const adapter = useMemo(() => new DeckAdapter({glContext}), [glContext]);
-
-  useEffect(() => {
-    dispatch(setupRenderer(adapter));
-  }, [adapter]);
+  const adapter = useSelector(adapterSelector);
 
   return (
     <Map

--- a/examples/worldview/src/features/renderer/index.js
+++ b/examples/worldview/src/features/renderer/index.js
@@ -15,7 +15,8 @@ export {
   timecodeChange,
   dimensionSelector,
   busySelector,
-  durationSelector
+  durationSelector,
+  adapterSelector
 } from './rendererSlice';
 
 export {useRenderHandler, usePreviewHandler} from './hooks';

--- a/examples/worldview/src/features/renderer/rendererMiddleware.js
+++ b/examples/worldview/src/features/renderer/rendererMiddleware.js
@@ -6,7 +6,6 @@ import {
   PreviewEncoder,
   GifEncoder
 } from '@hubble.gl/core';
-import {updateLayerFrame, updateCameraFrame} from '../timeline/timelineSlice';
 
 import {
   setupRenderer,
@@ -19,7 +18,8 @@ import {
   busySelector,
   timecodeSelector,
   filenameSelector,
-  formatConfigsSelector
+  formatConfigsSelector,
+  adapterSelector
 } from './rendererSlice';
 
 const ENCODERS = {
@@ -32,87 +32,84 @@ const ENCODERS = {
 const formatSelector = state => state.hubbleGl.renderer.format;
 const encoderSelector = state => ENCODERS[formatSelector(state)] || ENCODERS.webm;
 
-export const rendererMiddleware = store => {
-  let adapter;
-
-  return next => action => {
-    switch (action.type) {
-      case setupRenderer.type: {
-        if (busySelector(store.getState())) {
-          adapter.stop(() => {
-            store.dispatch(signalRendering(false)); // equivalent to signalPreviewing(false)
-            adapter = action.payload;
-          });
-        } else {
-          adapter = action.payload;
-        }
-        break;
-      }
-      case previewVideo.type: {
-        const {getCameraKeyframes, getLayerKeyframes, onStop} = action.payload;
-        const state = store.getState();
-        store.dispatch(signalPreviewing(true));
-        const innerOnStop = () => {
-          store.dispatch(signalPreviewing(false));
-          if (onStop) onStop();
-        };
-
-        adapter.render({
-          getCameraKeyframes,
-          Encoder: PreviewEncoder,
-          formatConfigs: formatConfigsSelector(state),
-          timecode: timecodeSelector(state),
-          filename: filenameSelector(state),
-          onStop: innerOnStop,
-          getLayerKeyframes
+export const rendererMiddleware = store => next => action => {
+  switch (action.type) {
+    case setupRenderer.type: {
+      if (busySelector(store.getState())) {
+        const adapter = adapterSelector(store.getState());
+        adapter.stop(() => {
+          store.dispatch(signalRendering(false)); // equivalent to signalPreviewing(false)
         });
-        break;
       }
-      case renderVideo.type: {
-        const {getCameraKeyframes, getLayerKeyframes, onStop} = action.payload;
-        const state = store.getState();
-        const Encoder = encoderSelector(state);
-
-        store.dispatch(signalRendering(true));
-
-        const innerOnStop = () => {
-          store.dispatch(signalRendering(false));
-          if (onStop) onStop();
-        };
-
-        adapter.render({
-          getCameraKeyframes,
-          Encoder,
-          formatConfigs: formatConfigsSelector(state),
-          timecode: timecodeSelector(state),
-          filename: filenameSelector(state),
-          onStop: innerOnStop,
-          getLayerKeyframes
-        });
-
-        break;
-      }
-      case stopVideo.type: {
-        if (busySelector(store.getState())) {
-          adapter.stop(() => {
-            store.dispatch(signalRendering(false)); // equivalent to signalPreviewing(false)
-          });
-        }
-        break;
-      }
-      case seekTime.type: {
-        if (!busySelector(store.getState()) && adapter && adapter.scene) {
-          adapter.seek(action.payload);
-          store.dispatch(updateCameraFrame(adapter.scene.getCameraFrame()));
-          store.dispatch(updateLayerFrame(adapter.scene.getLayerFrame()));
-        }
-        break;
-      }
-      default: {
-        break;
-      }
+      break;
     }
+    case previewVideo.type: {
+      const {getCameraKeyframes, getLayerKeyframes, onStop} = action.payload;
+      const state = store.getState();
+      store.dispatch(signalPreviewing(true));
+      const innerOnStop = () => {
+        store.dispatch(signalPreviewing(false));
+        if (onStop) onStop();
+      };
+      const adapter = adapterSelector(state);
+      adapter.render({
+        getCameraKeyframes,
+        Encoder: PreviewEncoder,
+        formatConfigs: formatConfigsSelector(state),
+        timecode: timecodeSelector(state),
+        filename: filenameSelector(state),
+        onStop: innerOnStop,
+        getLayerKeyframes
+      });
+      break;
+    }
+    case renderVideo.type: {
+      const {getCameraKeyframes, getLayerKeyframes, onStop} = action.payload;
+      const state = store.getState();
+      const Encoder = encoderSelector(state);
 
-    next(action);
-  };
+      store.dispatch(signalRendering(true));
+
+      const innerOnStop = () => {
+        store.dispatch(signalRendering(false));
+        if (onStop) onStop();
+      };
+      const adapter = adapterSelector(state);
+      adapter.render({
+        getCameraKeyframes,
+        Encoder,
+        formatConfigs: formatConfigsSelector(state),
+        timecode: timecodeSelector(state),
+        filename: filenameSelector(state),
+        onStop: innerOnStop,
+        getLayerKeyframes
+      });
+
+      break;
+    }
+    case stopVideo.type: {
+      const state = store.getState();
+      if (busySelector(state)) {
+        const adapter = adapterSelector(state);
+        adapter.stop(() => {
+          store.dispatch(signalRendering(false)); // equivalent to signalPreviewing(false)
+        });
+      }
+      break;
+    }
+    case seekTime.type: {
+      const state = store.getState();
+      if (!busySelector(state)) {
+        const adapter = adapterSelector(state);
+        adapter.seek(action.payload);
+      }
+      break;
+    }
+      }
+    default: {
+      break;
+    }
+  }
+
+  next(action);
 };

--- a/examples/worldview/src/features/renderer/rendererMiddleware.js
+++ b/examples/worldview/src/features/renderer/rendererMiddleware.js
@@ -105,7 +105,6 @@ export const rendererMiddleware = store => next => action => {
       }
       break;
     }
-      }
     default: {
       break;
     }

--- a/examples/worldview/src/features/renderer/rendererSlice.js
+++ b/examples/worldview/src/features/renderer/rendererSlice.js
@@ -1,9 +1,7 @@
 /* eslint-disable no-void */
 import {createAction, createSelector, nanoid, createSlice} from '@reduxjs/toolkit';
+import {DeckAdapter} from '@hubble.gl/core';
 import {DEFAULT_FILENAME, getResolutionSetting} from './constants';
-
-/** @param payload: adapter */
-export const setupRenderer = createAction('renderer/setupRenderer');
 
 /** @param payload: getCameraKeyframes, onStop */
 export const previewVideo = createAction('renderer/previewVideo');
@@ -34,6 +32,7 @@ function msToSec(ms) {
 const defaultResolution = getResolutionSetting();
 
 const initialState = {
+  adapter: new DeckAdapter({}),
   busy: false, // 'rendering' | 'previewing'
   dimensionState: defaultResolution,
   filename: DEFAULT_FILENAME,
@@ -107,6 +106,8 @@ const rendererSlice = createSlice({
   name: 'renderer',
   initialState,
   reducers: {
+    setupRenderer: (state, action /** payload: DeckAdapter */) =>
+      void (state.adapter = action.payload),
     filenameChange: filenameChangeSlice,
     formatChange: (state, action /** payload: string */) => void (state.format = action.payload),
     formatConfigsChange: (state, action /** payload: <{[Format]: {}}> */) => {
@@ -127,7 +128,8 @@ export const {
   formatChange,
   formatConfigsChange,
   resolutionChange,
-  timecodeChange
+  timecodeChange,
+  setupRenderer
 } = rendererSlice.actions;
 
 export default rendererSlice.reducer;
@@ -135,6 +137,7 @@ export default rendererSlice.reducer;
 /**
  * Selectors
  */
+export const adapterSelector = state => state.hubbleGl.renderer.adapter;
 
 export const framerateSelector = state => state.hubbleGl.renderer.timecodeState.framerate;
 export const framestepSelector = createSelector(framerateSelector, framerate => {


### PR DESCRIPTION
Since #119 and #112 simplified adapter construction, we can initialize the store adapter in the store right away instead of waiting for components to mount at runtime.