### PR TITLE
[enhancement] Refine kepler.gl keyframe generation

### DIFF
--- a/examples/worldview/src/features/map/Map.js
+++ b/examples/worldview/src/features/map/Map.js
@@ -95,9 +95,13 @@ export class Map extends Component {
     const map = this.mapRef.current.getMap();
     const deck = this.deckRef.current.deck;
 
-    // map.addLayer(new MapboxLayer({id: 'hubblegl-overlay', deck}));
     // var mapboxLayers = map.getStyle().layers;
     // console.log(mapboxLayers)
+
+    // If there aren't any layers, combine map and deck with a fake layer.
+    if (!layers.length) {
+      map.addLayer(new MapboxLayer({id: '%%blank-layer', deck}));
+    }
 
     for (let i = 0; i < layers.length; i++) {
       // TODO: layer mapbox and deck layers in order according to kepler config.


### PR DESCRIPTION
Match the kepler.gl animation controller initialization found in [bottom-widget](https://github.com/keplergl/kepler.gl/blob/14c35fc048a745faab0c6770cab7a4625ccedda3/src/components/bottom-widget.js#L148-L168)

- Only generate up to one filter keyframe, where `filter => filter.type === 'timeRange' && filter.enlarged` is true.
- Only generate up to one layer keyframe, where `showAnimationControl` is true.
```
const animatableLayer = layers.filter(
  l => l.config.animation && l.config.animation.enabled && l.config.isVisible
);
const readyToAnimation =
  Array.isArray(animationConfig.domain) && Number.isFinite(animationConfig.currentTime);
const showAnimationControl = animatableLayer.length && readyToAnimation;
```

