### PR TITLE
[enhancement] Correct zoom scale and bounds in kepler video export

### DIFF
--- a/examples/kepler-integration/src/components/export-video.js
+++ b/examples/kepler-integration/src/components/export-video.js
@@ -25,7 +25,7 @@ import styled, {withTheme} from 'styled-components';
 import {InjectKeplerUI, ExportVideoModal, ExportVideoPanelContainer} from '@hubble.gl/react';
 // Redux stores/actions
 import {toggleHubbleExportModal} from '../actions';
-import {setFilter, setLayerAnimationTime, updateMap} from 'kepler.gl/actions';
+import {setFilter, setLayerAnimationTime} from 'kepler.gl/actions';
 
 // Hook up mutual kepler imports
 import {
@@ -63,8 +63,7 @@ const mapStateToProps = state => {
 const mapDispatchToProps = {
   toggleHubbleExportModal,
   onFilterFrameUpdate: setFilter,
-  onTripFrameUpdate: setLayerAnimationTime,
-  onCameraFrameUpdate: updateMap
+  onTripFrameUpdate: setLayerAnimationTime
 };
 
 class ExportVideo extends Component {
@@ -82,14 +81,7 @@ class ExportVideo extends Component {
   }
 
   render() {
-    const {
-      mapData,
-      theme,
-      onFilterFrameUpdate,
-      onTripFrameUpdate,
-      onCameraFrameUpdate,
-      isVideoModalOpen
-    } = this.props;
+    const {mapData, theme, onFilterFrameUpdate, onTripFrameUpdate, isVideoModalOpen} = this.props;
     return (
       <InjectKeplerUI keplerUI={KEPLER_UI}>
         <div>
@@ -99,9 +91,6 @@ class ExportVideo extends Component {
               mapData={mapData}
               onFilterFrameUpdate={onFilterFrameUpdate}
               onTripFrameUpdate={onTripFrameUpdate}
-              onCameraFrameUpdate={onCameraFrameUpdate}
-              deckProps={{}}
-              staticMapProps={{}}
               exportVideoWidth={720}
             />
           </ExportVideoModal>

--- a/modules/react/src/components/export-video/export-video-panel-container.js
+++ b/modules/react/src/components/export-video/export-video-panel-container.js
@@ -31,7 +31,7 @@ import {
 } from '@hubble.gl/core';
 
 import ExportVideoPanel from './export-video-panel';
-import {parseSetCameraType} from './utils';
+import {parseSetCameraType, scaleToVideoExport} from './utils';
 import {DEFAULT_FILENAME, getResolutionSetting} from './constants';
 
 const ENCODERS = {
@@ -69,10 +69,10 @@ export class ExportVideoPanelContainer extends Component {
       fileName: '',
       resolution: '1280x720',
       durationMs: 1000,
-      viewState: mapState,
       rendering: false, // Will set a spinner overlay if true
       ...(initialState || {})
     };
+    this.state.viewState = scaleToVideoExport(mapState, this._getContainer());
     this.state.adapter = new DeckAdapter({glContext});
   }
 
@@ -98,6 +98,13 @@ export class ExportVideoPanelContainer extends Component {
   getCanvasSize() {
     const {resolution} = this.state;
     return getResolutionSetting(resolution);
+  }
+
+  _getContainer() {
+    const {width, height} = this.getCanvasSize();
+    const {exportVideoWidth} = this.props;
+    const aspectRatio = width / height;
+    return {height: exportVideoWidth / aspectRatio, width: exportVideoWidth};
   }
 
   getFormatConfigs() {

--- a/modules/react/src/components/export-video/export-video-panel-container.js
+++ b/modules/react/src/components/export-video/export-video-panel-container.js
@@ -31,7 +31,7 @@ import {
 } from '@hubble.gl/core';
 
 import ExportVideoPanel from './export-video-panel';
-import {parseSetCameraType, filterCamera} from './utils';
+import {parseSetCameraType} from './utils';
 import {DEFAULT_FILENAME, getResolutionSetting} from './constants';
 
 const ENCODERS = {
@@ -234,10 +234,6 @@ export class ExportVideoPanelContainer extends Component {
   }
 
   setViewState(viewState) {
-    const {onCameraFrameUpdate} = this.props;
-    if (onCameraFrameUpdate) {
-      onCameraFrameUpdate(filterCamera(viewState));
-    }
     this.setState({viewState});
   }
 
@@ -346,5 +342,7 @@ export class ExportVideoPanelContainer extends Component {
 ExportVideoPanelContainer.defaultProps = {
   exportVideoWidth: 540,
   header: true,
-  glContext: undefined
+  glContext: undefined,
+  deckProps: {},
+  staticMapProps: {}
 };

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -130,7 +130,7 @@ export class ExportVideoPanelPreview extends Component {
       idx,
       interactionConfig,
       layerCallbacks,
-      mapState: {...mapState, ...viewState, ...this._getContainer()},
+      mapState: {...mapState, ...viewState},
       animationConfig,
       objectHovered
     });

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -101,7 +101,8 @@ export class ExportVideoPanelPreview extends Component {
 
   _renderLayer(overlays, idx) {
     const {
-      mapData: {visState, mapState}
+      mapData: {visState, mapState},
+      viewState
     } = this.props;
 
     const {
@@ -130,7 +131,7 @@ export class ExportVideoPanelPreview extends Component {
       idx,
       interactionConfig,
       layerCallbacks,
-      mapState,
+      mapState: {...mapState, ...viewState},
       animationConfig,
       objectHovered
     });

--- a/modules/react/src/components/export-video/export-video-panel-preview.js
+++ b/modules/react/src/components/export-video/export-video-panel-preview.js
@@ -46,7 +46,6 @@ export class ExportVideoPanelPreview extends Component {
     this._renderLayer = this._renderLayer.bind(this);
     this._onMapLoad = this._onMapLoad.bind(this);
     this._resizeVideo = this._resizeVideo.bind(this);
-    this._getContainerHeight = this._getContainerHeight.bind(this);
     this._resizeVideo();
   }
 
@@ -131,17 +130,17 @@ export class ExportVideoPanelPreview extends Component {
       idx,
       interactionConfig,
       layerCallbacks,
-      mapState: {...mapState, ...viewState},
+      mapState: {...mapState, ...viewState, ...this._getContainer()},
       animationConfig,
       objectHovered
     });
     return overlays.concat(layerOverlay || []);
   }
 
-  _getContainerHeight() {
+  _getContainer() {
     const {exportVideoWidth, resolution} = this.props;
     const aspectRatio = resolution[0] / resolution[1];
-    return exportVideoWidth / aspectRatio;
+    return {height: exportVideoWidth / aspectRatio, width: exportVideoWidth};
   }
 
   createLayers() {
@@ -174,7 +173,6 @@ export class ExportVideoPanelPreview extends Component {
 
   render() {
     const {
-      exportVideoWidth,
       rendering,
       viewState,
       setViewState,
@@ -186,9 +184,11 @@ export class ExportVideoPanelPreview extends Component {
     } = this.props;
     const {glContext, mapStyle} = this.state;
     const deck = this.deckRef.current && this.deckRef.current.deck;
+
+    const {width, height} = this._getContainer();
     const containerStyle = {
-      width: `${exportVideoWidth}px`,
-      height: `${this._getContainerHeight()}px`,
+      width: `${width}px`,
+      height: `${height}px`,
       position: 'relative'
     };
 
@@ -225,8 +225,8 @@ export class ExportVideoPanelPreview extends Component {
         {rendering && (
           <RenderingSpinner
             rendering={rendering}
-            width={exportVideoWidth}
-            height={this._getContainerHeight()}
+            width={width}
+            height={height}
             adapter={adapter}
             durationMs={durationMs}
           />

--- a/modules/react/src/components/export-video/utils.js
+++ b/modules/react/src/components/export-video/utils.js
@@ -120,13 +120,3 @@ export function estimateFileSize(frameRate, resolution, durationMs, mediaType) {
   }
   return 'Size estimation unavailable';
 }
-
-export function filterCamera(viewState) {
-  const exclude = ['width', 'height', 'altitude'];
-  return Object.keys(viewState)
-    .filter(key => !exclude.includes(key))
-    .reduce((obj, key) => {
-      obj[key] = viewState[key];
-      return obj;
-    }, {});
-}

--- a/modules/react/src/components/export-video/utils.js
+++ b/modules/react/src/components/export-video/utils.js
@@ -20,6 +20,20 @@
 
 import {point} from '@turf/helpers';
 import transformTranslate from '@turf/transform-translate';
+import {WebMercatorViewport} from '@deck.gl/core';
+
+export function scaleToVideoExport(viewState, container) {
+  const viewport = new WebMercatorViewport(viewState);
+  const nw = viewport.unproject([0, 0]);
+  const se = viewport.unproject([viewport.width, viewport.height]);
+  const videoViewport = new WebMercatorViewport({
+    ...viewState,
+    width: container.width,
+    height: container.height
+  }).fitBounds([nw, se]);
+  const {height, width, latitude, longitude, pitch, zoom, bearing, altitude} = videoViewport;
+  return {height, width, latitude, longitude, pitch, zoom, bearing, altitude};
+}
 
 /**
  * Parses camera type and creates keyframe for Hubble to use


### PR DESCRIPTION
Modifies the export window's viewState to match the main map bounds using `WebMercatorViewport.fitBounds`.

<img width="1788" alt="Screen Shot 2021-07-05 at 4 17 22 PM" src="https://user-images.githubusercontent.com/2461547/124645841-c6d82e00-de48-11eb-9df7-60ecb71af287.png">

#### TODO
- [x] Disconnect kepler mapState from animation viewState.
- [x] Scale export viewState to match bounds of main map
- [ ] Layer zoom scale modified to match main map

#### References from kepler (using a different approach):
https://github.com/keplergl/kepler.gl/blob/master/src/utils/export-utils.js#L70-L91
https://github.com/keplergl/kepler.gl/blob/master/src/components/plot-container.js#L160-L172