### PR TITLE
[bug] remove double install of react-intl

### DIFF
--- a/examples/kepler-integration/package.json
+++ b/examples/kepler-integration/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "d3-request": "^1.0.6",
     "global": "^4.3.0",
-    "hubble.gl": "^1.1.0",
     "react-map-gl": "^5.2.10",
     "react-markdown": "^4.2.2",
     "react-palm": "^3.3.6",

--- a/examples/worldview/package.json
+++ b/examples/worldview/package.json
@@ -15,7 +15,6 @@
     "@reduxjs/toolkit": "^1.5.0",
     "d3-request": "^1.0.6",
     "global": "^4.3.0",
-    "hubble.gl": "^1.1.0",
     "lodash.isequal": "^4.5.0",
     "react-copy-to-clipboard": "^5.0.3",
     "react-helmet": "^6.1.0",

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -41,7 +41,6 @@
     "lodash.uniqby": "^4.7.0",
     "popmotion": "^8.6.10",
     "prop-types": "^15.7.2",
-    "react-intl": "^3.12.0",
     "react-lifecycles-compat": "^3.0.4",
     "react-map-gl": "^5.2.10",
     "react-modal": "^3.11.2",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-map-gl": "^5.2.10",
+    "react-intl": "^3.12.0",
     "react-redux": "^7.1.3",
     "react-virtualized": "^9.21.0",
     "styled-components": "^4.4.1"


### PR DESCRIPTION
The pinned `hubble.gl` version in our examples were pulling `react-intl` from the published `@hubble.gl/react`. But `@hubble.gl/react` doesn't use `react-intl` anymore, so that should be removed. Once the new alpha is released, examples can include `hubble.gl` again, but this isn't necessary when using `yarn start-local`.