### PR TITLE
[Chore] remove redundant mapState updater

### DIFF
--- a/examples/worldview/src/features/kepler/keplerSlice.js
+++ b/examples/worldview/src/features/kepler/keplerSlice.js
@@ -18,18 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import keplerGlReducer, {mapStateUpdaters} from 'kepler.gl/reducers';
-import {updateViewState} from '../map';
-
-export default keplerGlReducer.plugin({
-  [updateViewState]: (state, action) => {
-    return {
-      ...state,
-      mapState: mapStateUpdaters.updateMapUpdater(state.mapState, action)
-    };
-  }
-});
-
 const isKeplerReady = (state, mapId) => {
   if (state.keplerGl[mapId]) return true;
   return false;

--- a/examples/worldview/src/features/map/Map.js
+++ b/examples/worldview/src/features/map/Map.js
@@ -146,7 +146,7 @@ export class Map extends Component {
       <div id="deck-canvas" style={containerStyle}>
         <DeckGL
           ref={this.deckRef}
-          viewState={viewState}
+          viewState={{...viewState, maxPitch: 90}}
           id="hubblegl-overlay"
           style={deckStyle}
           controller={true}

--- a/examples/worldview/src/store.js
+++ b/examples/worldview/src/store.js
@@ -20,13 +20,13 @@
 
 import {combineReducers, createStore, applyMiddleware, compose} from 'redux';
 import {enhanceReduxMiddleware} from 'kepler.gl/middleware';
+import keplerGlReducer from 'kepler.gl/reducers';
 import thunk from 'redux-thunk';
 import {rendererMiddleware} from './features/renderer';
 // eslint-disable-next-line no-unused-vars
 import window from 'global/window';
 
 import {appReducer} from './app';
-import keplerGlReducer from './features/kepler/keplerSlice';
 
 import rendererReducer from './features/renderer/rendererSlice';
 import {mapReducer} from './features/map';


### PR DESCRIPTION
No longer needed because of #138 mixing map states. [See code.](https://github.com/visgl/hubble.gl/pull/138/files#diff-4aa7e84885f07005eab98d8366f1059ae82081cbef449ab841d55862541891e2R61)
