### PR TITLE
fix(kepler export) match 3d perspective in video export

### DIFF
--- a/modules/react/src/components/export-video/utils.js
+++ b/modules/react/src/components/export-video/utils.js
@@ -31,8 +31,17 @@ export function scaleToVideoExport(viewState, container) {
     width: container.width,
     height: container.height
   }).fitBounds([nw, se]);
-  const {height, width, latitude, longitude, pitch, zoom, bearing, altitude} = videoViewport;
-  return {height, width, latitude, longitude, pitch, zoom, bearing, altitude};
+  const {height, width, latitude, longitude, zoom, altitude} = videoViewport;
+  return {
+    height,
+    width,
+    latitude,
+    longitude,
+    pitch: viewState.pitch,
+    zoom,
+    bearing: viewState.bearing,
+    altitude
+  };
 }
 
 /**


### PR DESCRIPTION
Video export 3d mode appeared broken when pitch/bearing aren't preserved. This is a workaround since we WebMercatorViewport doesn't have a `fitPerspectiveBounds`.

**Before**

https://user-images.githubusercontent.com/2461547/136463184-9e9af75d-23c9-44e9-89d2-ac5d7a196fe4.mov

**After**

https://user-images.githubusercontent.com/2461547/136463198-ca53194d-9446-4853-b3e0-83bedb08bd64.mov

