### PR TITLE
add(kepler) default filename prop

### DIFF
--- a/examples/kepler-integration/src/components/export-video.js
+++ b/examples/kepler-integration/src/components/export-video.js
@@ -94,6 +94,7 @@ class ExportVideo extends Component {
               onFilterFrameUpdate={onFilterFrameUpdate}
               onTripFrameUpdate={onTripFrameUpdate}
               exportVideoWidth={720}
+              defaultFileName={'hubble.gl'}
             />
           </ExportVideoModal>
         </div>

--- a/modules/react/src/components/export-video/export-video-panel-container.js
+++ b/modules/react/src/components/export-video/export-video-panel-container.js
@@ -93,8 +93,9 @@ export class ExportVideoPanelContainer extends Component {
   }
 
   getFileName() {
+    const {defaultFileName} = this.props;
     const {fileName} = this.state;
-    if (fileName === '') return DEFAULT_FILENAME;
+    if (fileName === '') return defaultFileName;
     return fileName;
   }
 
@@ -311,7 +312,8 @@ export class ExportVideoPanelContainer extends Component {
       deckProps,
       staticMapProps,
       disableStaticMap,
-      mapboxLayerBeforeId
+      mapboxLayerBeforeId,
+      defaultFileName
     } = this.props;
     const {
       adapter,
@@ -333,6 +335,7 @@ export class ExportVideoPanelContainer extends Component {
       setCameraPreset: this.setCameraPreset,
       fileName,
       setFileName: this.setFileName,
+      fileNamePlaceholder: defaultFileName,
       resolution,
       setResolution: this.setResolution,
       durationMs,
@@ -380,5 +383,6 @@ ExportVideoPanelContainer.defaultProps = {
   glContext: undefined,
   deckProps: {},
   staticMapProps: {},
-  disableStaticMap: false
+  disableStaticMap: false,
+  defaultFileName: DEFAULT_FILENAME
 };

--- a/modules/react/src/components/export-video/modal-tab-settings.js
+++ b/modules/react/src/components/export-video/modal-tab-settings.js
@@ -2,13 +2,7 @@ import React, {useState} from 'react';
 
 import {estimateFileSize} from './utils';
 import {StyledLabelCell, StyledValueCell, InputGrid} from './styled-components';
-import {
-  DEFAULT_FILENAME,
-  FORMATS,
-  RESOLUTIONS,
-  ASPECT_RATIOS,
-  DEFAULT_PREVIEW_RESOLUTIONS
-} from './constants';
+import {FORMATS, RESOLUTIONS, ASPECT_RATIOS, DEFAULT_PREVIEW_RESOLUTIONS} from './constants';
 import {WithKeplerUI} from '../inject-kepler';
 
 const getOptionValue = r => r.value;
@@ -25,7 +19,7 @@ function SettingsTab({settings, resolution}) {
             <StyledLabelCell>File Name</StyledLabelCell>
             <Input
               value={settings.fileName}
-              placeholder={DEFAULT_FILENAME}
+              placeholder={settings.fileNamePlaceholder}
               onChange={e => settings.setFileName(e.target.value)}
             />
             <StyledLabelCell>Media Type</StyledLabelCell>


### PR DESCRIPTION
**Changelog**
Set default filename prop to set input placeholder and default filename.
```jsx
<ExportVideoPanelContainer
  ...
  defaultFileName={'hubble.gl'}
/>
```
![Screen Shot 2021-10-11 at 4 56 40 PM](https://user-images.githubusercontent.com/2461547/136868857-9a19a8eb-d179-4fea-aa72-35ca65c80e4d.png)
![Screen Shot 2021-10-11 at 4 56 44 PM](https://user-images.githubusercontent.com/2461547/136868862-4fa21e86-5429-46e3-9b0a-0c4e9cbb4f82.png)
![Screen Shot 2021-10-11 at 4 56 49 PM](https://user-images.githubusercontent.com/2461547/136868864-90afa58c-f870-4baf-9d6a-09dfc590569a.png)
