### PR TITLE
fix(examples) mapbox 2.5 introducing scaling issue

### DIFF
--- a/examples/trips/package.json
+++ b/examples/trips/package.json
@@ -24,5 +24,8 @@
     "webpack": "^4.20.2",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.11"
+  },
+  "resolutions": {
+    "mapbox-gl": "2.4.1"
   }
 }

--- a/examples/worldview/package.json
+++ b/examples/worldview/package.json
@@ -37,5 +37,8 @@
     "webpack-dev-middleware": "^3.5.1",
     "webpack-dev-server": "^3.1.14",
     "webpack-hot-middleware": "^2.24.3"
+  },
+  "resolutions": {
+    "mapbox-gl": "2.4.1"
   }
 }

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -58,6 +58,7 @@
     "kepler.gl": ">=2.3.2",
     "react": ">=16.8",
     "react-dom": ">=16.8",
-    "styled-components": ">=4.0"
+    "styled-components": ">=4.0",
+    "mapbox-gl": "<=2.4.1"
   }
 }


### PR DESCRIPTION
Pin to <=2.4 until patch for 2.5 is released.

**Expected**

<img width="564" alt="Screen Shot 2021-10-13 at 5 27 15 PM" src="https://user-images.githubusercontent.com/2461547/137242575-17d061d9-97c1-4921-9ddb-1ced1ff90b6b.png">

**Actual**

![Screen Shot 2021-10-13 at 7 50 48 PM](https://user-images.githubusercontent.com/2461547/137242614-c55d4f3b-1bf0-4003-b7c8-127b32bc2dd1.png)

