### PR TITLE
fix(release) failing github-release script

### DIFF
--- a/scripts/github-release.js
+++ b/scripts/github-release.js
@@ -40,7 +40,7 @@ function getGitTag() {
 
 function getReleaseNotes(version) {
   let changelog = readFileSync('CHANGELOG.md', 'utf-8');
-  const header = changelog.match(new RegExp(`^###.*\\b${version.replace('v', '')}\\b.*$`, 'm'));
+  const header = changelog.match(new RegExp(`^###.*\\b${version}\\b.*$`, 'm'));
   if (!header) {
     return null;
   }


### PR DESCRIPTION
### Background

`CHANGELOG.md` now always contains `v` prefix, since vis.gl dev-tools validates for this. This had the unintended side effect of breaking the `github-release` script, which was expecting the version number without the `v` prefix.

### Change List

- remove broken regex